### PR TITLE
Integrate with cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # IDE
 .idea
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # C++
 /build
+/cmake-build-*
 
 # Rust
 /target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+crate-type = ["staticlib", "rlib"]
+
 [dependencies]
 cxx = { version = "1.0.109", features = ["c++17"] }
 

--- a/build.rs
+++ b/build.rs
@@ -333,10 +333,13 @@ const SOURCES: &[&str] = &[
 ];
 
 fn main() {
+    // This will be called when building rocksdb-rs from cmake.
+    if let Ok("1") = std::env::var("SKIP_BUILD_SCRIPT").as_deref() {
+        return;
+    }
+
     let target = std::env::var("TARGET").unwrap();
-
     let includes = ["rocksdb-cxx/include", "rocksdb-cxx"];
-
     let mut config = cxx_build::bridge("src/lib.rs");
 
     config.flag("-pthread");

--- a/rocksdb-cxx/CMakeLists.txt
+++ b/rocksdb-cxx/CMakeLists.txt
@@ -1418,7 +1418,6 @@ if(WITH_TESTS)
         OUTPUT_NAME ${exename}${ARTIFACT_SUFFIX}
       )
       target_link_libraries(${exename}${ARTIFACT_SUFFIX}
-        PUBLIC rocksdb-rs-cxx
         PRIVATE testutillib${ARTIFACT_SUFFIX} testharness gtest ${THIRDPARTY_LIBS} ${ROCKSDB_LIB})
       if(NOT "${exename}" MATCHES "db_sanity_test")
         gtest_discover_tests(${exename} DISCOVERY_TIMEOUT 120)

--- a/rocksdb-cxx/CMakeLists.txt
+++ b/rocksdb-cxx/CMakeLists.txt
@@ -35,6 +35,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
+include(FetchContent)
 include(ReadVersion)
 include(GoogleTest)
 get_rocksdb_version(rocksdb_VERSION)
@@ -43,6 +44,12 @@ project(rocksdb
   DESCRIPTION "An embeddable persistent key-value store for fast storage"
   HOMEPAGE_URL https://rocksdb.org/
   LANGUAGES CXX C ASM)
+
+FetchContent_Declare(
+  Corrosion
+  GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+)
+FetchContent_MakeAvailable(Corrosion)
 
 if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
@@ -1102,14 +1109,21 @@ string(REGEX REPLACE "[^0-9: /-]+" "" GIT_DATE "${GIT_DATE}")
 set(BUILD_VERSION_CC ${CMAKE_BINARY_DIR}/build_version.cc)
 configure_file(util/build_version.cc.in ${BUILD_VERSION_CC} @ONLY)
 
+corrosion_import_crate(MANIFEST_PATH ../Cargo.toml)
+corrosion_set_env_vars(rocksdb-rs SKIP_BUILD_SCRIPT=1)
+corrosion_add_cxxbridge(rocksdb-rs-cxx CRATE rocksdb-rs FILES lib.rs)
+target_include_directories(rocksdb-rs-cxx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(${ROCKSDB_STATIC_LIB} STATIC ${SOURCES} ${BUILD_VERSION_CC})
-target_link_libraries(${ROCKSDB_STATIC_LIB} PRIVATE
-  ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+target_link_libraries(${ROCKSDB_STATIC_LIB}
+  PUBLIC rocksdb-rs-cxx
+  PRIVATE ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 
 if(ROCKSDB_BUILD_SHARED)
   add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES} ${BUILD_VERSION_CC})
-  target_link_libraries(${ROCKSDB_SHARED_LIB} PRIVATE
-    ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+  target_link_libraries(${ROCKSDB_SHARED_LIB}
+    PUBLIC rocksdb-rs-cxx
+    PRIVATE ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 
   if(WIN32)
     set_target_properties(${ROCKSDB_SHARED_LIB} PROPERTIES
@@ -1403,7 +1417,9 @@ if(WITH_TESTS)
         EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO 1
         OUTPUT_NAME ${exename}${ARTIFACT_SUFFIX}
       )
-      target_link_libraries(${exename}${ARTIFACT_SUFFIX} testutillib${ARTIFACT_SUFFIX} testharness gtest ${THIRDPARTY_LIBS} ${ROCKSDB_LIB})
+      target_link_libraries(${exename}${ARTIFACT_SUFFIX}
+        PUBLIC rocksdb-rs-cxx
+        PRIVATE testutillib${ARTIFACT_SUFFIX} testharness gtest ${THIRDPARTY_LIBS} ${ROCKSDB_LIB})
       if(NOT "${exename}" MATCHES "db_sanity_test")
         gtest_discover_tests(${exename} DISCOVERY_TIMEOUT 120)
         add_dependencies(check ${exename}${ARTIFACT_SUFFIX})

--- a/rocksdb-cxx/env/env_basic_test.cc
+++ b/rocksdb-cxx/env/env_basic_test.cc
@@ -14,6 +14,7 @@
 #include "rocksdb/convenience.h"
 #include "rocksdb/env.h"
 #include "rocksdb/env_encryption.h"
+#include "rocksdb-rs-cxx/lib.h"
 #include "test_util/testharness.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -145,6 +146,14 @@ INSTANTIATE_TEST_CASE_P(CustomEnv, EnvBasicTestWithParam,
 
 INSTANTIATE_TEST_CASE_P(CustomEnv, EnvMoreTestWithParam,
                         ::testing::ValuesIn(GetCustomEnvs()));
+
+TEST_P(EnvBasicTestWithParam, RustIntegration) {
+    CommonRustData common = {.value = "integration"};
+    ASSERT_EQ(common.value, "integration");
+
+    rust::String value = hello_common(common);
+    ASSERT_EQ(value, "Hello integration from rust!");
+}
 
 TEST_P(EnvBasicTestWithParam, Basics) {
   uint64_t file_size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use crate::ffi::CommonRustData;
+
 #[cxx::bridge(namespace = "rocksdb")]
 pub mod ffi {
     unsafe extern "C++" {
@@ -11,6 +13,18 @@ pub mod ffi {
         #[cxx_name = "HelloWorld"]
         fn hello_world(&self) -> UniquePtr<CxxString>;
     }
+
+    extern "Rust" {
+        fn hello_common(data: &CommonRustData) -> String;
+    }
+
+    struct CommonRustData {
+        value: String,
+    }
+}
+
+pub fn hello_common(data: &CommonRustData) -> String {
+    format!("Hello {} from rust!", data.value)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This integrates the existing codebase to build from cmake too since there are many tests and examples which are still built via cmake.