### PR TITLE
Remove Status == and != operators

### DIFF
--- a/rocksdb-cxx/cache/cache_reservation_manager.cc
+++ b/rocksdb-cxx/cache/cache_reservation_manager.cc
@@ -115,7 +115,7 @@ Status CacheReservationManagerImpl<R>::IncreaseCacheReservation(
     Cache::Handle* handle = nullptr;
     return_status = cache_.Insert(GetNextCacheKey(), kSizeDummyEntry, &handle);
 
-    if (return_status != Status_OK()) {
+    if (!return_status.eq(Status_OK())) {
       return return_status;
     }
 

--- a/rocksdb-cxx/cache/cache_reservation_manager_test.cc
+++ b/rocksdb-cxx/cache/cache_reservation_manager_test.cc
@@ -40,7 +40,7 @@ class CacheReservationManagerTest : public ::testing::Test {
 TEST_F(CacheReservationManagerTest, GenerateCacheKey) {
   std::size_t new_mem_used = 1 * kSizeDummyEntry;
   Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_GE(cache->GetPinnedUsage(), 1 * kSizeDummyEntry);
   ASSERT_LT(cache->GetPinnedUsage(),
             1 * kSizeDummyEntry + kMetaDataChargeOverhead);
@@ -66,7 +66,7 @@ TEST_F(CacheReservationManagerTest, GenerateCacheKey) {
 TEST_F(CacheReservationManagerTest, KeepCacheReservationTheSame) {
   std::size_t new_mem_used = 1 * kSizeDummyEntry;
   Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             1 * kSizeDummyEntry);
   ASSERT_EQ(test_cache_rev_mng->GetTotalMemoryUsed(), new_mem_used);
@@ -76,7 +76,7 @@ TEST_F(CacheReservationManagerTest, KeepCacheReservationTheSame) {
             1 * kSizeDummyEntry + kMetaDataChargeOverhead);
 
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK())
+  EXPECT_TRUE(s.eq(Status_OK()))
       << "Failed to keep cache reservation the same when new_mem_used equals "
          "to current cache reservation";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
@@ -95,7 +95,7 @@ TEST_F(CacheReservationManagerTest,
        IncreaseCacheReservationByMultiplesOfDummyEntrySize) {
   std::size_t new_mem_used = 2 * kSizeDummyEntry;
   Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK())
+  EXPECT_TRUE(s.eq(Status_OK()))
       << "Failed to increase cache reservation correctly";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             2 * kSizeDummyEntry)
@@ -113,7 +113,7 @@ TEST_F(CacheReservationManagerTest,
        IncreaseCacheReservationNotByMultiplesOfDummyEntrySize) {
   std::size_t new_mem_used = 2 * kSizeDummyEntry + kSizeDummyEntry / 2;
   Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK())
+  EXPECT_TRUE(s.eq(Status_OK()))
       << "Failed to increase cache reservation correctly";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             3 * kSizeDummyEntry)
@@ -147,7 +147,7 @@ TEST(CacheReservationManagerIncreaseReservcationOnFullCacheTest,
 
   std::size_t new_mem_used = kSmallCacheCapacity + 1;
   Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_MemoryLimit())
+  EXPECT_TRUE(s.eq(Status_MemoryLimit()))
       << "Failed to return status to indicate failure of dummy entry insertion "
          "during cache reservation on full cache";
   EXPECT_GE(test_cache_rev_mng->GetTotalReservedCacheSize(),
@@ -170,7 +170,7 @@ TEST(CacheReservationManagerIncreaseReservcationOnFullCacheTest,
 
   new_mem_used = kSmallCacheCapacity / 2;  // 2 dummy entries
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK())
+  EXPECT_TRUE(s.eq(Status_OK()))
       << "Failed to decrease cache reservation after encountering cache "
          "reservation failure due to full cache";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
@@ -192,7 +192,7 @@ TEST(CacheReservationManagerIncreaseReservcationOnFullCacheTest,
   // Create cache full again for subsequent tests
   new_mem_used = kSmallCacheCapacity + 1;
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_MemoryLimit())
+  EXPECT_TRUE(s.eq(Status_MemoryLimit()))
       << "Failed to return status to indicate failure of dummy entry insertion "
          "during cache reservation on full cache";
   EXPECT_GE(test_cache_rev_mng->GetTotalReservedCacheSize(),
@@ -218,7 +218,7 @@ TEST(CacheReservationManagerIncreaseReservcationOnFullCacheTest,
   cache->SetCapacity(kBigCacheCapacity);
   new_mem_used = kSmallCacheCapacity + 1;
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK())
+  EXPECT_TRUE(s.eq(Status_OK()))
       << "Failed to increase cache reservation after increasing cache capacity "
          "and mitigating cache full error";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
@@ -240,7 +240,7 @@ TEST_F(CacheReservationManagerTest,
        DecreaseCacheReservationByMultiplesOfDummyEntrySize) {
   std::size_t new_mem_used = 2 * kSizeDummyEntry;
   Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             2 * kSizeDummyEntry);
   ASSERT_EQ(test_cache_rev_mng->GetTotalMemoryUsed(), new_mem_used);
@@ -250,7 +250,7 @@ TEST_F(CacheReservationManagerTest,
 
   new_mem_used = 1 * kSizeDummyEntry;
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK())
+  EXPECT_TRUE(s.eq(Status_OK()))
       << "Failed to decrease cache reservation correctly";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             1 * kSizeDummyEntry)
@@ -268,7 +268,7 @@ TEST_F(CacheReservationManagerTest,
        DecreaseCacheReservationNotByMultiplesOfDummyEntrySize) {
   std::size_t new_mem_used = 2 * kSizeDummyEntry;
   Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             2 * kSizeDummyEntry);
   ASSERT_EQ(test_cache_rev_mng->GetTotalMemoryUsed(), new_mem_used);
@@ -278,7 +278,7 @@ TEST_F(CacheReservationManagerTest,
 
   new_mem_used = kSizeDummyEntry / 2;
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK())
+  EXPECT_TRUE(s.eq(Status_OK()))
       << "Failed to decrease cache reservation correctly";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             1 * kSizeDummyEntry)
@@ -309,7 +309,7 @@ TEST(CacheReservationManagerWithDelayedDecreaseTest,
 
   std::size_t new_mem_used = 8 * kSizeDummyEntry;
   Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             8 * kSizeDummyEntry);
   ASSERT_EQ(test_cache_rev_mng->GetTotalMemoryUsed(), new_mem_used);
@@ -320,7 +320,7 @@ TEST(CacheReservationManagerWithDelayedDecreaseTest,
 
   new_mem_used = 6 * kSizeDummyEntry;
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK()) << "Failed to delay decreasing cache reservation";
+  EXPECT_TRUE(s.eq(Status_OK())) << "Failed to delay decreasing cache reservation";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             8 * kSizeDummyEntry)
       << "Failed to bookkeep correctly when delaying cache reservation "
@@ -332,7 +332,7 @@ TEST(CacheReservationManagerWithDelayedDecreaseTest,
 
   new_mem_used = 7 * kSizeDummyEntry;
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK()) << "Failed to delay decreasing cache reservation";
+  EXPECT_TRUE(s.eq(Status_OK())) << "Failed to delay decreasing cache reservation";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
             8 * kSizeDummyEntry)
       << "Failed to bookkeep correctly when delaying cache reservation "
@@ -344,7 +344,7 @@ TEST(CacheReservationManagerWithDelayedDecreaseTest,
 
   new_mem_used = 6 * kSizeDummyEntry - 1;
   s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-  EXPECT_EQ(s, Status_OK())
+  EXPECT_TRUE(s.eq(Status_OK()))
       << "Failed to decrease cache reservation correctly when new_mem_used < "
          "GetTotalReservedCacheSize() * 3 / 4 on delayed decrease mode";
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(),
@@ -381,7 +381,7 @@ TEST(CacheReservationManagerDestructorTest,
             cache);
     std::size_t new_mem_used = 1 * kSizeDummyEntry;
     Status s = test_cache_rev_mng->UpdateCacheReservation(new_mem_used);
-    ASSERT_EQ(s, Status_OK());
+    ASSERT_TRUE(s.eq(Status_OK()));
     ASSERT_GE(cache->GetPinnedUsage(), 1 * kSizeDummyEntry);
     ASSERT_LT(cache->GetPinnedUsage(),
               1 * kSizeDummyEntry + kMetaDataChargeOverhead);
@@ -417,7 +417,7 @@ TEST(CacheReservationHandleTest, HandleTest) {
   Status s = test_cache_rev_mng->MakeCacheReservation(
       incremental_mem_used_handle_1, &handle_1);
   mem_used = mem_used + incremental_mem_used_handle_1;
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   EXPECT_TRUE(handle_1 != nullptr);
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(), mem_used);
   EXPECT_EQ(test_cache_rev_mng->GetTotalMemoryUsed(), mem_used);
@@ -427,7 +427,7 @@ TEST(CacheReservationHandleTest, HandleTest) {
   s = test_cache_rev_mng->MakeCacheReservation(incremental_mem_used_handle_2,
                                                &handle_2);
   mem_used = mem_used + incremental_mem_used_handle_2;
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   EXPECT_TRUE(handle_2 != nullptr);
   EXPECT_EQ(test_cache_rev_mng->GetTotalReservedCacheSize(), mem_used);
   EXPECT_EQ(test_cache_rev_mng->GetTotalMemoryUsed(), mem_used);

--- a/rocksdb-cxx/db/blob/db_blob_index_test.cc
+++ b/rocksdb-cxx/db/blob/db_blob_index_test.cc
@@ -499,7 +499,7 @@ TEST_F(DBBlobIndexTest, IntegratedBlobIterate) {
 
   auto check_iterator = [&](Iterator* iterator, Status expected_status,
                             const Slice& expected_value) {
-    ASSERT_EQ(expected_status, iterator->status());
+    ASSERT_TRUE(expected_status.eq(iterator->status()));
     if (expected_status.ok()) {
       ASSERT_TRUE(iterator->Valid());
       ASSERT_EQ(expected_value, iterator->value());

--- a/rocksdb-cxx/db/compact_files_test.cc
+++ b/rocksdb-cxx/db/compact_files_test.cc
@@ -229,7 +229,7 @@ TEST_F(CompactFilesTest, ObsoleteFiles) {
 
   // verify all compaction input files are deleted
   for (auto fname : l0_files) {
-    ASSERT_EQ(Status_NotFound(), env_->FileExists(fname));
+    ASSERT_TRUE(Status_NotFound().eq(env_->FileExists(fname)));
   }
   delete db;
 }

--- a/rocksdb-cxx/db/corruption_test.cc
+++ b/rocksdb-cxx/db/corruption_test.cc
@@ -1330,8 +1330,8 @@ TEST_P(CrashDuringRecoveryWithCorruptionTest, CrashDuringRecovery) {
 
       // Since  it's corrupting second last wal, below key is not found.
       v.clear();
-      ASSERT_EQ(db_->Get(ReadOptions(), "key" + std::to_string(1), &v),
-                Status_NotFound());
+      ASSERT_TRUE(db_->Get(ReadOptions(), "key" + std::to_string(1), &v).eq(
+                Status_NotFound()));
     }
 
     for (auto* h : handles) {
@@ -1505,8 +1505,8 @@ TEST_P(CrashDuringRecoveryWithCorruptionTest, TxnDbCrashDuringRecovery) {
     {
       std::string v;
       // Key not visible since it's not committed.
-      ASSERT_EQ(txn_db->Get(ReadOptions(), handles[1], "foo", &v),
-                Status_NotFound());
+      ASSERT_TRUE(txn_db->Get(ReadOptions(), handles[1], "foo", &v).eq(
+                Status_NotFound()));
 
       v.clear();
       ASSERT_OK(txn_db->Get(ReadOptions(), "key" + std::to_string(0), &v));
@@ -1514,11 +1514,11 @@ TEST_P(CrashDuringRecoveryWithCorruptionTest, TxnDbCrashDuringRecovery) {
 
       // Last WAL is corrupted which contains two keys below.
       v.clear();
-      ASSERT_EQ(txn_db->Get(ReadOptions(), "key" + std::to_string(1), &v),
-                Status_NotFound());
+      ASSERT_TRUE(txn_db->Get(ReadOptions(), "key" + std::to_string(1), &v).eq(
+                Status_NotFound()));
       v.clear();
-      ASSERT_EQ(txn_db->Get(ReadOptions(), handles[1], "foo1", &v),
-                Status_NotFound());
+      ASSERT_TRUE(txn_db->Get(ReadOptions(), handles[1], "foo1", &v).eq(
+                Status_NotFound()));
     }
 
     for (auto* h : handles) {
@@ -1666,8 +1666,8 @@ TEST_P(CrashDuringRecoveryWithCorruptionTest, CrashDuringRecoveryWithFlush) {
 
       // Since it's corrupting last wal after Flush, below key is not found.
       v.clear();
-      ASSERT_EQ(db_->Get(ReadOptions(), handles[1], "dontcare", &v),
-                Status_NotFound());
+      ASSERT_TRUE(db_->Get(ReadOptions(), handles[1], "dontcare", &v).eq(
+                Status_NotFound()));
     }
 
     for (auto* h : handles) {

--- a/rocksdb-cxx/db/db_basic_test.cc
+++ b/rocksdb-cxx/db/db_basic_test.cc
@@ -1268,15 +1268,15 @@ TEST_F(DBBasicTest, DBCloseFlushError) {
   ASSERT_OK(Put("key3", "value3"));
   fault_injection_env->SetFilesystemActive(false);
   Status s = dbfull()->Close();
-  ASSERT_NE(s, Status_OK());
+  ASSERT_FALSE(s.eq(Status_OK()));
   // retry should return the same error
   s = dbfull()->Close();
-  ASSERT_NE(s, Status_OK());
+  ASSERT_FALSE(s.eq(Status_OK()));
   fault_injection_env->SetFilesystemActive(true);
   // retry close() is no-op even the system is back. Could be improved if
   // Close() is retry-able: #9029
   s = dbfull()->Close();
-  ASSERT_NE(s, Status_OK());
+  ASSERT_FALSE(s.eq(Status_OK()));
   Destroy(options);
 }
 
@@ -4223,7 +4223,7 @@ class DBBasicTestMultiGetDeadline : public DBBasicTestMultiGet,
       if (i < num_ok) {
         EXPECT_OK(statuses[i]);
       } else {
-        if (statuses[i] != Status_TimedOut()) {
+        if (!statuses[i].eq(Status_TimedOut())) {
           EXPECT_EQ(statuses[i], Status_TimedOut());
         }
       }

--- a/rocksdb-cxx/db/db_basic_test.cc
+++ b/rocksdb-cxx/db/db_basic_test.cc
@@ -1192,7 +1192,7 @@ TEST_F(DBBasicTest, DBClose) {
 
   s = db->Close();
   ASSERT_EQ(env->GetCloseCount(), 1);
-  ASSERT_EQ(s, Status_IOError());
+  ASSERT_TRUE(s.eq(Status_IOError()));
 
   delete db;
   ASSERT_EQ(env->GetCloseCount(), 1);
@@ -1212,7 +1212,7 @@ TEST_F(DBBasicTest, DBClose) {
   ASSERT_TRUE(db != nullptr);
 
   s = db->Close();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   delete db;
   ASSERT_EQ(env->GetCloseCount(), 2);
   options.info_log.reset();
@@ -2329,9 +2329,9 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL1) {
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data());
   ASSERT_EQ(values.size(), 3);
-  ASSERT_EQ(statuses[0], Status_OK());
-  ASSERT_EQ(statuses[1], Status_OK());
-  ASSERT_EQ(statuses[2], Status_OK());
+  ASSERT_TRUE(statuses[0].eq(Status_OK()));
+  ASSERT_TRUE(statuses[1].eq(Status_OK()));
+  ASSERT_TRUE(statuses[2].eq(Status_OK()));
   ASSERT_EQ(values[0], "val_l1_" + std::to_string(33));
   ASSERT_EQ(values[1], "val_l1_" + std::to_string(54));
   ASSERT_EQ(values[2], "val_l1_" + std::to_string(102));
@@ -2400,9 +2400,9 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL1Error) {
                      keys.data(), values.data(), statuses.data());
   SyncPoint::GetInstance()->DisableProcessing();
   ASSERT_EQ(values.size(), 3);
-  ASSERT_EQ(statuses[0], Status_OK());
-  ASSERT_EQ(statuses[1], Status_OK());
-  ASSERT_EQ(statuses[2], Status_IOError());
+  ASSERT_TRUE(statuses[0].eq(Status_OK()));
+  ASSERT_TRUE(statuses[1].eq(Status_OK()));
+  ASSERT_TRUE(statuses[2].eq(Status_IOError()));
 
   HistogramData multiget_io_batch_size;
 
@@ -2439,9 +2439,9 @@ TEST_P(DBMultiGetAsyncIOTest, LastKeyInFile) {
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data());
   ASSERT_EQ(values.size(), 3);
-  ASSERT_EQ(statuses[0], Status_OK());
-  ASSERT_EQ(statuses[1], Status_OK());
-  ASSERT_EQ(statuses[2], Status_OK());
+  ASSERT_TRUE(statuses[0].eq(Status_OK()));
+  ASSERT_TRUE(statuses[1].eq(Status_OK()));
+  ASSERT_TRUE(statuses[2].eq(Status_OK()));
   ASSERT_EQ(values[0], "val_l1_" + std::to_string(21));
   ASSERT_EQ(values[1], "val_l1_" + std::to_string(54));
   ASSERT_EQ(values[2], "val_l1_" + std::to_string(102));
@@ -2484,9 +2484,9 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL1AndL2) {
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data());
   ASSERT_EQ(values.size(), 3);
-  ASSERT_EQ(statuses[0], Status_OK());
-  ASSERT_EQ(statuses[1], Status_OK());
-  ASSERT_EQ(statuses[2], Status_OK());
+  ASSERT_TRUE(statuses[0].eq(Status_OK()));
+  ASSERT_TRUE(statuses[1].eq(Status_OK()));
+  ASSERT_TRUE(statuses[2].eq(Status_OK()));
   ASSERT_EQ(values[0], "val_l1_" + std::to_string(33));
   ASSERT_EQ(values[1], "val_l2_" + std::to_string(56));
   ASSERT_EQ(values[2], "val_l1_" + std::to_string(102));
@@ -2526,8 +2526,8 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL2WithRangeOverlapL0L1) {
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data());
   ASSERT_EQ(values.size(), 2);
-  ASSERT_EQ(statuses[0], Status_OK());
-  ASSERT_EQ(statuses[1], Status_OK());
+  ASSERT_TRUE(statuses[0].eq(Status_OK()));
+  ASSERT_TRUE(statuses[1].eq(Status_OK()));
   ASSERT_EQ(values[0], "val_l2_" + std::to_string(19));
   ASSERT_EQ(values[1], "val_l2_" + std::to_string(26));
 
@@ -2562,8 +2562,8 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL2WithRangeDelInL1) {
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data());
   ASSERT_EQ(values.size(), 2);
-  ASSERT_EQ(statuses[0], Status_NotFound());
-  ASSERT_EQ(statuses[1], Status_NotFound());
+  ASSERT_TRUE(statuses[0].eq(Status_NotFound()));
+  ASSERT_TRUE(statuses[1].eq(Status_NotFound()));
 
   // Bloom filters in L0/L1 will avoid the coroutine calls in those levels
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 2);
@@ -2593,10 +2593,10 @@ TEST_P(DBMultiGetAsyncIOTest, GetFromL1AndL2WithRangeDelInL1) {
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data());
   ASSERT_EQ(values.size(), keys.size());
-  ASSERT_EQ(statuses[0], Status_NotFound());
-  ASSERT_EQ(statuses[1], Status_OK());
+  ASSERT_TRUE(statuses[0].eq(Status_NotFound()));
+  ASSERT_TRUE(statuses[1].eq(Status_OK()));
   ASSERT_EQ(values[1], "val_l1_" + std::to_string(144));
-  ASSERT_EQ(statuses[2], Status_NotFound());
+  ASSERT_TRUE(statuses[2].eq(Status_NotFound()));
 
   // Bloom filters in L0/L1 will avoid the coroutine calls in those levels
   ASSERT_EQ(statistics()->getTickerCount(MULTIGET_COROUTINE_COUNT), 3);
@@ -2627,9 +2627,9 @@ TEST_P(DBMultiGetAsyncIOTest, GetNoIOUring) {
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data());
   ASSERT_EQ(values.size(), 3);
-  ASSERT_EQ(statuses[0], Status_OK());
-  ASSERT_EQ(statuses[1], Status_OK());
-  ASSERT_EQ(statuses[2], Status_OK());
+  ASSERT_TRUE(statuses[0].eq(Status_OK()));
+  ASSERT_TRUE(statuses[1].eq(Status_OK()));
+  ASSERT_TRUE(statuses[2].eq(Status_OK()));
 
   HistogramData async_read_bytes;
 
@@ -2979,7 +2979,7 @@ TEST_F(DBBasicTest, MultiGetIOBufferOverrun) {
     // Make the value compressible. A purely random string doesn't compress
     // and the resultant data block will not be compressed
     std::string value(rnd.RandomString(128) + zero_str);
-    assert(Put(Key(i), value) == Status_OK());
+    assert(Put(Key(i), value).eq(Status_OK()));
   }
   ASSERT_OK(Flush());
 
@@ -3506,7 +3506,7 @@ class DBBasicTestMultiGet : public DBTestBase {
         // and the resultant data block will not be compressed
         values_.emplace_back(rnd.RandomString(128) + zero_str);
         assert(((num_cfs == 1) ? Put(Key(i), values_[i])
-                               : Put(cf, Key(i), values_[i])) == Status_OK());
+                               : Put(cf, Key(i), values_[i])).eq(Status_OK()));
       }
       if (num_cfs == 1) {
         EXPECT_OK(Flush());
@@ -3519,8 +3519,7 @@ class DBBasicTestMultiGet : public DBTestBase {
         uncompressable_values_.emplace_back(rnd.RandomString(256) + '\0');
         std::string tmp_key = "a" + Key(i);
         assert(((num_cfs == 1) ? Put(tmp_key, uncompressable_values_[i])
-                               : Put(cf, tmp_key, uncompressable_values_[i])) ==
-               Status_OK());
+                               : Put(cf, tmp_key, uncompressable_values_[i])).eq(Status_OK()));
       }
       if (num_cfs == 1) {
         EXPECT_OK(Flush());
@@ -3944,8 +3943,8 @@ TEST_P(DBBasicTestWithParallelIO, MultiGetWithChecksumMismatch) {
                      keys.data(), values.data(), statuses.data(), true);
   ASSERT_TRUE(CheckValue(0, values[0].ToString()));
   // ASSERT_TRUE(CheckValue(50, values[1].ToString()));
-  ASSERT_EQ(statuses[0], Status_OK());
-  ASSERT_EQ(statuses[1], Status_Corruption());
+  ASSERT_TRUE(statuses[0].eq(Status_OK()));
+  ASSERT_TRUE(statuses[1].eq(Status_Corruption()));
 
   SyncPoint::GetInstance()->DisableProcessing();
 }
@@ -3990,8 +3989,8 @@ TEST_P(DBBasicTestWithParallelIO, MultiGetWithMissingFile) {
 
   dbfull()->MultiGet(ro, dbfull()->DefaultColumnFamily(), keys.size(),
                      keys.data(), values.data(), statuses.data(), true);
-  ASSERT_EQ(statuses[0], Status_IOError());
-  ASSERT_EQ(statuses[1], Status_IOError());
+  ASSERT_TRUE(statuses[0].eq(Status_IOError()));
+  ASSERT_TRUE(statuses[1].eq(Status_IOError()));
 
   SyncPoint::GetInstance()->DisableProcessing();
 }
@@ -4224,7 +4223,7 @@ class DBBasicTestMultiGetDeadline : public DBBasicTestMultiGet,
         EXPECT_OK(statuses[i]);
       } else {
         if (!statuses[i].eq(Status_TimedOut())) {
-          EXPECT_EQ(statuses[i], Status_TimedOut());
+          EXPECT_TRUE(statuses[i].eq(Status_TimedOut()));
         }
       }
     }
@@ -4659,7 +4658,7 @@ TEST_P(DBBasicTestDeadline, PointLookupDeadline) {
       std::string value;
       Status s = dbfull()->Get(ro, "k50", &value);
       if (fs->TimedOut()) {
-        ASSERT_EQ(s, Status_TimedOut());
+        ASSERT_TRUE(s.eq(Status_TimedOut()));
       } else {
         timedout = false;
         ASSERT_OK(s);
@@ -4746,7 +4745,7 @@ TEST_P(DBBasicTestDeadline, IteratorDeadline) {
       }
       if (fs->TimedOut()) {
         ASSERT_FALSE(iter->Valid());
-        ASSERT_EQ(iter->status(), Status_TimedOut());
+        ASSERT_TRUE(iter->status().eq(Status_TimedOut()));
       } else {
         timedout = false;
         ASSERT_OK(iter->status());

--- a/rocksdb-cxx/db/db_compaction_test.cc
+++ b/rocksdb-cxx/db/db_compaction_test.cc
@@ -8530,12 +8530,12 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff1) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   Destroy(options);
   Reopen(options);
 
@@ -8546,7 +8546,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff1) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::FlushMemTable:FlushMemTableFinished",
         "BackgroundCallCompaction:0"}});
@@ -8557,7 +8557,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff1) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
   ASSERT_EQ(s.severity(),
             ROCKSDB_NAMESPACE::Severity::kUnrecoverableError);
@@ -8571,12 +8571,12 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff1) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
 
   // Each write will be similated as corrupted.
   // Since the file system returns IOStatus::Corruption, it is an
@@ -8585,7 +8585,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff1) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::FlushMemTable:FlushMemTableFinished",
         "BackgroundCallCompaction:0"}});
@@ -8595,7 +8595,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff1) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
   ASSERT_EQ(s.severity(),
             ROCKSDB_NAMESPACE::Severity::kUnrecoverableError);
@@ -8624,12 +8624,12 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff2) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   Destroy(options);
   Reopen(options);
 
@@ -8637,7 +8637,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff2) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::FlushMemTable:FlushMemTableFinished",
         "BackgroundCallCompaction:0"}});
@@ -8648,9 +8648,9 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff2) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   SyncPoint::GetInstance()->DisableProcessing();
   Destroy(options);
   Reopen(options);
@@ -8661,19 +8661,19 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff2) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
 
   // options is not set, the checksum handoff will not be triggered
   fault_fs->SetChecksumHandoffFuncType(ChecksumType::kCRC32c);
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::FlushMemTable:FlushMemTableFinished",
         "BackgroundCallCompaction:0"}});
@@ -8683,9 +8683,9 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoff2) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
 
   Destroy(options);
 }
@@ -8711,12 +8711,12 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoffManifest1) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   Destroy(options);
   Reopen(options);
 
@@ -8727,7 +8727,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoffManifest1) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::FlushMemTable:FlushMemTableFinished",
         "BackgroundCallCompaction:0"}});
@@ -8738,7 +8738,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoffManifest1) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
   ASSERT_EQ(s.severity(), ROCKSDB_NAMESPACE::Severity::kFatalError);
   SyncPoint::GetInstance()->DisableProcessing();
@@ -8768,12 +8768,12 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoffManifest2) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
 
   // Each write will be similated as corrupted.
   // Since the file system returns IOStatus::Corruption, it is mapped to
@@ -8782,7 +8782,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoffManifest2) {
   ASSERT_OK(Put(Key(0), "value1"));
   ASSERT_OK(Put(Key(2), "value2"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {{"DBImpl::FlushMemTable:FlushMemTableFinished",
         "BackgroundCallCompaction:0"}});
@@ -8792,7 +8792,7 @@ TEST_F(DBCompactionTest, CompactionWithChecksumHandoffManifest2) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
   ASSERT_OK(Put(Key(1), "value3"));
   s = Flush();
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   s = dbfull()->TEST_WaitForCompact();
   ASSERT_EQ(s.severity(), ROCKSDB_NAMESPACE::Severity::kFatalError);
   SyncPoint::GetInstance()->DisableProcessing();

--- a/rocksdb-cxx/db/db_flush_test.cc
+++ b/rocksdb-cxx/db/db_flush_test.cc
@@ -1911,7 +1911,7 @@ TEST_F(DBFlushTest, FlushError) {
   Status s = dbfull()->TEST_SwitchMemtable();
   fault_injection_env->SetFilesystemActive(true);
   Destroy(options);
-  ASSERT_NE(s, Status_OK());
+  ASSERT_FALSE(s.eq(Status_OK()));
 }
 
 TEST_F(DBFlushTest, ManualFlushFailsInReadOnlyMode) {

--- a/rocksdb-cxx/db/db_impl/db_impl_compaction_flush.cc
+++ b/rocksdb-cxx/db/db_impl/db_impl_compaction_flush.cc
@@ -327,7 +327,7 @@ Status DBImpl::FlushMemTableToOutputFile(
         error_handler_.SetBGError(s, BackgroundErrorReason::kFlushNoWAL);
       }
     } else {
-      assert(s == log_io_s);
+      assert(s.eq(log_io_s));
       Status new_bg_error = s;
       error_handler_.SetBGError(new_bg_error, BackgroundErrorReason::kFlush);
     }
@@ -800,7 +800,7 @@ Status DBImpl::AtomicFlushMemTablesToOutputFiles(
         error_handler_.SetBGError(s, BackgroundErrorReason::kFlushNoWAL);
       }
     } else {
-      assert(s == log_io_s);
+      assert(s.eq(log_io_s));
       Status new_bg_error = s;
       error_handler_.SetBGError(new_bg_error, BackgroundErrorReason::kFlush);
     }

--- a/rocksdb-cxx/db/db_sst_test.cc
+++ b/rocksdb-cxx/db/db_sst_test.cc
@@ -274,7 +274,7 @@ TEST_F(DBSSTTest, DeleteObsoleteFilesPendingOutputs) {
   ASSERT_EQ(metadata.size(), 2U);
 
   // This file should have been deleted during last compaction
-  ASSERT_EQ(Status_NotFound(), env_->FileExists(dbname_ + file_on_L2));
+  ASSERT_TRUE(Status_NotFound().eq(env_->FileExists(dbname_ + file_on_L2)));
   listener->VerifyMatchedCount(1);
 }
 

--- a/rocksdb-cxx/db/db_test.cc
+++ b/rocksdb-cxx/db/db_test.cc
@@ -6945,7 +6945,7 @@ TEST_F(DBTest, PinnableSliceAndRowCache) {
 
   {
     PinnableSlice pin_slice;
-    ASSERT_EQ(Get("foo", &pin_slice), Status_OK());
+    ASSERT_TRUE(Get("foo", &pin_slice).eq(Status_OK()));
     ASSERT_EQ(pin_slice.ToString(), "bar");
     // Entry is already in cache, lookup will remove the element from lru
     ASSERT_EQ(
@@ -6974,8 +6974,8 @@ TEST_F(DBTest, ReusePinnableSlice) {
 
   {
     PinnableSlice pin_slice;
-    ASSERT_EQ(Get("foo", &pin_slice), Status_OK());
-    ASSERT_EQ(Get("foo", &pin_slice), Status_OK());
+    ASSERT_TRUE(Get("foo", &pin_slice).eq(Status_OK()));
+    ASSERT_TRUE(Get("foo", &pin_slice).eq(Status_OK()));
     ASSERT_EQ(pin_slice.ToString(), "bar");
 
     // Entry is already in cache, lookup will remove the element from lru
@@ -6997,11 +6997,11 @@ TEST_F(DBTest, ReusePinnableSlice) {
     dbfull()->MultiGet(ropt, dbfull()->DefaultColumnFamily(),
                        multiget_keys.size(), multiget_keys.data(),
                        multiget_values.data(), statuses.data());
-    ASSERT_EQ(Status_OK(), statuses[0]);
+    ASSERT_TRUE(Status_OK().eq(statuses[0]));
     dbfull()->MultiGet(ropt, dbfull()->DefaultColumnFamily(),
                        multiget_keys.size(), multiget_keys.data(),
                        multiget_values.data(), statuses.data());
-    ASSERT_EQ(Status_OK(), statuses[0]);
+    ASSERT_TRUE(Status_OK().eq(statuses[0]));
 
     // Entry is already in cache, lookup will remove the element from lru
     ASSERT_EQ(
@@ -7024,11 +7024,11 @@ TEST_F(DBTest, ReusePinnableSlice) {
     dbfull()->MultiGet(ropt, multiget_keys.size(), multiget_cfs.data(),
                        multiget_keys.data(), multiget_values.data(),
                        statuses.data());
-    ASSERT_EQ(Status_OK(), statuses[0]);
+    ASSERT_TRUE(Status_OK().eq(statuses[0]));
     dbfull()->MultiGet(ropt, multiget_keys.size(), multiget_cfs.data(),
                        multiget_keys.data(), multiget_values.data(),
                        statuses.data());
-    ASSERT_EQ(Status_OK(), statuses[0]);
+    ASSERT_TRUE(Status_OK().eq(statuses[0]));
 
     // Entry is already in cache, lookup will remove the element from lru
     ASSERT_EQ(
@@ -7237,7 +7237,7 @@ TEST_F(DBTest, CreationTimeOfOldestFile) {
   uint64_t creation_time;
   Status s1 = dbfull()->GetCreationTimeOfOldestFile(&creation_time);
   ASSERT_EQ(0, creation_time);
-  ASSERT_EQ(s1, Status_OK());
+  ASSERT_TRUE(s1.eq(Status_OK()));
 
   // Testing with non-zero file creation time.
   set_file_creation_time_to_zero = false;
@@ -7262,14 +7262,14 @@ TEST_F(DBTest, CreationTimeOfOldestFile) {
   uint64_t ctime;
   Status s2 = dbfull()->GetCreationTimeOfOldestFile(&ctime);
   ASSERT_EQ(uint_time_1, ctime);
-  ASSERT_EQ(s2, Status_OK());
+  ASSERT_TRUE(s2.eq(Status_OK()));
 
   // Testing with max_open_files != -1
   options = CurrentOptions();
   options.max_open_files = 10;
   DestroyAndReopen(options);
   Status s3 = dbfull()->GetCreationTimeOfOldestFile(&ctime);
-  ASSERT_EQ(s3, Status_NotSupported());
+  ASSERT_TRUE(s3.eq(Status_NotSupported()));
 
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
 }

--- a/rocksdb-cxx/db/db_test2.cc
+++ b/rocksdb-cxx/db/db_test2.cc
@@ -5155,7 +5155,7 @@ TEST_F(DBTest2, PinnableSliceAndMmapReads) {
   ASSERT_OK(Flush());
 
   PinnableSlice pinned_value;
-  ASSERT_EQ(Get("foo", &pinned_value), Status_OK());
+  ASSERT_TRUE(Get("foo", &pinned_value).eq(Status_OK()));
   // It is not safe to pin mmap files as they might disappear by compaction
   ASSERT_FALSE(pinned_value.IsPinned());
   ASSERT_EQ(pinned_value.ToString(), "bar");
@@ -5172,7 +5172,7 @@ TEST_F(DBTest2, PinnableSliceAndMmapReads) {
   // Unsafe to pin mmap files when they could be kicked out of table cache
   Close();
   ASSERT_OK(ReadOnlyReopen(options));
-  ASSERT_EQ(Get("foo", &pinned_value), Status_OK());
+  ASSERT_TRUE(Get("foo", &pinned_value).eq(Status_OK()));
   ASSERT_FALSE(pinned_value.IsPinned());
   ASSERT_EQ(pinned_value.ToString(), "bar");
 
@@ -5182,7 +5182,7 @@ TEST_F(DBTest2, PinnableSliceAndMmapReads) {
   Close();
   options.max_open_files = -1;
   ASSERT_OK(ReadOnlyReopen(options));
-  ASSERT_EQ(Get("foo", &pinned_value), Status_OK());
+  ASSERT_TRUE(Get("foo", &pinned_value).eq(Status_OK()));
   ASSERT_TRUE(pinned_value.IsPinned());
   ASSERT_EQ(pinned_value.ToString(), "bar");
 }

--- a/rocksdb-cxx/db/db_test_util.cc
+++ b/rocksdb-cxx/db/db_test_util.cc
@@ -990,8 +990,8 @@ std::string DBTestBase::AllEntriesFor(const Slice& user_key, int cf) {
     bool first = true;
     while (iter->Valid()) {
       ParsedInternalKey ikey(Slice(), 0, kTypeValue);
-      if (ParseInternalKey(iter->key(), &ikey, true /* log_err_key */) !=
-          Status_OK()) {
+      if (!ParseInternalKey(iter->key(), &ikey, true /* log_err_key */)
+          .eq(Status_OK())) {
         result += "CORRUPTED";
       } else {
         if (!last_options_.comparator->Equal(ikey.user_key, user_key)) {

--- a/rocksdb-cxx/db/db_test_util.cc
+++ b/rocksdb-cxx/db/db_test_util.cc
@@ -1560,7 +1560,7 @@ void DBTestBase::VerifyDBFromMap(std::map<std::string, std::string> true_data,
       ASSERT_EQ(Get(kv.first), kv.second);
     } else {
       std::string value;
-      ASSERT_EQ(s, db_->Get(ReadOptions(), kv.first, &value));
+      ASSERT_TRUE(s.eq(db_->Get(ReadOptions(), kv.first, &value)));
     }
     total_reads++;
   }
@@ -1587,7 +1587,7 @@ void DBTestBase::VerifyDBFromMap(std::map<std::string, std::string> true_data,
       if (!current_status.ok()) {
         s = current_status;
       }
-      ASSERT_EQ(iter->status(), s);
+      ASSERT_TRUE(iter->status().eq(s));
       if (current_status.ok()) {
         ASSERT_EQ(iter->value().ToString(), data_iter->second);
       }
@@ -1616,7 +1616,7 @@ void DBTestBase::VerifyDBFromMap(std::map<std::string, std::string> true_data,
       if (!current_status.ok()) {
         s = current_status;
       }
-      ASSERT_EQ(iter->status(), s);
+      ASSERT_TRUE(iter->status().eq(s));
       if (current_status.ok()) {
         ASSERT_EQ(iter->value().ToString(), data_rev->second);
       }

--- a/rocksdb-cxx/db/db_wal_test.cc
+++ b/rocksdb-cxx/db/db_wal_test.cc
@@ -38,7 +38,7 @@ class DBWALTestBase : public DBTestBase {
     int alloc_status = fallocate(fd, 0, 0, 1);
     int err_number = errno;
     close(fd);
-    assert(env_->DeleteFile(fname_test_fallocate) == Status_OK());
+    assert(env_->DeleteFile(fname_test_fallocate).eq(Status_OK()));
     if (err_number == ENOSYS || err_number == EOPNOTSUPP) {
       fprintf(stderr, "Skipped preallocated space check: %s\n",
               errnoStr(err_number).c_str());

--- a/rocksdb-cxx/db/db_with_timestamp_basic_test.cc
+++ b/rocksdb-cxx/db/db_with_timestamp_basic_test.cc
@@ -367,30 +367,30 @@ TEST_F(DBBasicTestWithTimestamp, UpdateFullHistoryTsLowWithPublicAPI) {
   std::string ts_low_str_back = Timestamp(8, 0);
   auto s = db_->IncreaseFullHistoryTsLow(db_->DefaultColumnFamily(),
                                          ts_low_str_back);
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
   // test IncreaseFullHistoryTsLow with a timestamp whose length is longger
   // than the cf's timestamp size
   std::string ts_low_str_long(Timestamp(0, 0).size() + 1, 'a');
   s = db_->IncreaseFullHistoryTsLow(db_->DefaultColumnFamily(),
                                     ts_low_str_long);
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
   // test IncreaseFullHistoryTsLow with a timestamp which is null
   std::string ts_low_str_null = "";
   s = db_->IncreaseFullHistoryTsLow(db_->DefaultColumnFamily(),
                                     ts_low_str_null);
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
   // test IncreaseFullHistoryTsLow for a column family that does not enable
   // timestamp
   options.comparator = BytewiseComparator();
   DestroyAndReopen(options);
   ts_low_str = Timestamp(10, 0);
   s = db_->IncreaseFullHistoryTsLow(db_->DefaultColumnFamily(), ts_low_str);
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
   // test GetFullHistoryTsLow for a column family that does not enable
   // timestamp
   std::string current_ts_low;
   s = db_->GetFullHistoryTsLow(db_->DefaultColumnFamily(), &current_ts_low);
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
   Close();
 }
 
@@ -568,7 +568,7 @@ TEST_F(DBBasicTestWithTimestamp, TrimHistoryTest) {
     std::string value;
     std::string key_ts;
     Status s = db->Get(ropts, key, &value, &key_ts);
-    ASSERT_TRUE(s == status);
+    ASSERT_TRUE(s.eq(status));
     if (s.ok()) {
       ASSERT_EQ(checkValue, value);
     }
@@ -3674,8 +3674,8 @@ TEST_F(DBBasicTestWithTimestamp, DeleteRangeGetIteratorWithSnapshot) {
     Status s = Status_new();
     for (int i = 0; i < kNum; ++i) {
       s = db_->Get(read_opts, Key1(i), &value, &timestamp);
-      ASSERT_EQ(s, expected_status[i]);
-      ASSERT_EQ(statuses[i], expected_status[i]);
+      ASSERT_TRUE(s.eq(expected_status[i]));
+      ASSERT_TRUE(statuses[i].eq(expected_status[i]));
       if (s.ok()) {
         ASSERT_EQ(value, expected_values[i]);
         ASSERT_EQ(values[i], expected_values[i]);

--- a/rocksdb-cxx/db/error_handler.cc
+++ b/rocksdb-cxx/db/error_handler.cc
@@ -528,7 +528,7 @@ Status ErrorHandler::OverrideNoSpaceError(const Status& bg_error,
   {
     uint64_t free_space;
     if (db_options_.env->GetFreeSpace(db_options_.db_paths[0].path,
-                                      &free_space) == Status_NotSupported()) {
+                                      &free_space).eq(Status_NotSupported())) {
       *auto_recovery = false;
     }
   }

--- a/rocksdb-cxx/db/error_handler_fs_test.cc
+++ b/rocksdb-cxx/db/error_handler_fs_test.cc
@@ -1298,7 +1298,7 @@ TEST_F(DBErrorHandlingFSTest, WALWriteError) {
     WriteOptions wopts;
     wopts.sync = true;
     s = dbfull()->Write(wopts, &batch);
-    ASSERT_EQ(s, Status_NoSpace());
+    ASSERT_TRUE(s.eq(Status_NoSpace()));
   }
   SyncPoint::GetInstance()->DisableProcessing();
   // `ClearAllCallBacks()` is needed in addition to `DisableProcessing()` to
@@ -2462,7 +2462,7 @@ TEST_F(DBErrorHandlingFSTest, FLushWritRetryableErrorAbortRecovery) {
   s = Flush();
   ASSERT_EQ(s.severity(), ROCKSDB_NAMESPACE::Severity::kSoftError);
   ASSERT_EQ(listener->WaitForRecovery(5000000), true);
-  ASSERT_EQ(listener->new_bg_error(), Status_Aborted());
+  ASSERT_TRUE(listener->new_bg_error().eq(Status_Aborted()));
   SyncPoint::GetInstance()->DisableProcessing();
   fault_fs_->SetFilesystemActive(true);
 

--- a/rocksdb-cxx/db/external_sst_file_basic_test.cc
+++ b/rocksdb-cxx/db/external_sst_file_basic_test.cc
@@ -673,7 +673,7 @@ TEST_F(ExternalSSTFileBasicTest, NoCopy) {
 
   s = DeprecatedAddFile({file1}, true /* move file */);
   ASSERT_OK(s) << s.ToString();
-  ASSERT_EQ(Status_NotFound(), env_->FileExists(file1));
+  ASSERT_TRUE(Status_NotFound().eq(env_->FileExists(file1)));
 
   s = DeprecatedAddFile({file2}, false /* copy file */);
   ASSERT_OK(s) << s.ToString();

--- a/rocksdb-cxx/db/fault_injection_test.cc
+++ b/rocksdb-cxx/db/fault_injection_test.cc
@@ -542,7 +542,7 @@ TEST_P(FaultInjectionTest, WriteBatchWalTerminationTest) {
   std::string val;
   ASSERT_OK(db_->Get(ro, "cats", &val));
   ASSERT_EQ("dogs", val);
-  ASSERT_EQ(db_->Get(ro, "boys", &val), Status_NotFound());
+  ASSERT_TRUE(db_->Get(ro, "boys", &val).eq(Status_NotFound()));
 }
 
 TEST_P(FaultInjectionTest, NoDuplicateTrailingEntries) {

--- a/rocksdb-cxx/db/import_column_family_test.cc
+++ b/rocksdb-cxx/db/import_column_family_test.cc
@@ -872,9 +872,8 @@ TEST_F(ImportColumnFamilyTest, ImportMultiColumnFamilyWithOverlap) {
   std::vector<const ExportImportFilesMetaData*> metadatas = {metadata_ptr_,
                                                              metadata_ptr2_};
 
-  ASSERT_EQ(db_->CreateColumnFamilyWithImport(options, "toto", import_options,
-                                              metadatas, &import_cfh_),
-            Status_InvalidArgument("CFs have overlapping ranges"));
+  ASSERT_TRUE(db_->CreateColumnFamilyWithImport(options, "toto", import_options, metadatas, &import_cfh_)
+            .eq(Status_InvalidArgument("CFs have overlapping ranges")));
 
   ASSERT_OK(db_copy->DropColumnFamily(copy_cfh));
   ASSERT_OK(db_copy->DestroyColumnFamilyHandle(copy_cfh));

--- a/rocksdb-cxx/db/version_set.cc
+++ b/rocksdb-cxx/db/version_set.cc
@@ -1229,7 +1229,7 @@ void LevelIterator::Seek(const Slice& target) {
     // blocks has been submitted. So it should return at this point and Seek
     // should be called again to retrieve the requested block and execute the
     // remaining code.
-    if (file_iter_.status() == Status_TryAgain()) {
+    if (file_iter_.status().eq(Status_TryAgain())) {
       return;
     }
     if (!file_iter_.Valid() && file_iter_.status().ok() &&

--- a/rocksdb-cxx/db/write_batch_test.cc
+++ b/rocksdb-cxx/db/write_batch_test.cc
@@ -439,7 +439,7 @@ TEST_F(WriteBatchTest, PrepareCommit) {
   batch.SetSavePoint();
   ASSERT_OK(WriteBatchInternal::MarkEndPrepare(&batch, Slice("xid1")));
   Status s = batch.RollbackToSavePoint();
-  ASSERT_EQ(s, Status_NotFound());
+  ASSERT_TRUE(s.eq(Status_NotFound()));
   ASSERT_OK(WriteBatchInternal::MarkCommit(&batch, Slice("xid1")));
   ASSERT_OK(WriteBatchInternal::MarkRollback(&batch, Slice("xid1")));
   ASSERT_EQ(2u, batch.Count());

--- a/rocksdb-cxx/db_stress_tool/db_stress_test_base.cc
+++ b/rocksdb-cxx/db_stress_tool/db_stress_test_base.cc
@@ -363,7 +363,7 @@ Status StressTest::AssertSame(DB* db, ColumnFamilyHandle* cf,
   if (!s.ok() && !s.IsNotFound()) {
     return s;
   }
-  if (snap_state.status != s) {
+  if (!snap_state.status.eq(s)) {
     return Status_Corruption(
         "The snapshot gave inconsistent results for key " +
         std::to_string(Hash(snap_state.key.c_str(), snap_state.key.size(), 0)) +

--- a/rocksdb-cxx/env/env_basic_test.cc
+++ b/rocksdb-cxx/env/env_basic_test.cc
@@ -166,7 +166,7 @@ TEST_P(EnvBasicTestWithParam, Basics) {
   std::vector<std::string> children;
 
   // Check that the directory is empty.
-  ASSERT_EQ(Status_NotFound(), env_->FileExists(test_dir_ + "/non_existent"));
+  ASSERT_TRUE(Status_NotFound().eq(env_->FileExists(test_dir_ + "/non_existent")));
   ASSERT_TRUE(!env_->GetFileSize(test_dir_ + "/non_existent", &file_size).ok());
   ASSERT_OK(env_->GetChildren(test_dir_, &children));
   ASSERT_EQ(0U, children.size());
@@ -204,7 +204,7 @@ TEST_P(EnvBasicTestWithParam, Basics) {
   ASSERT_TRUE(
       !env_->RenameFile(test_dir_ + "/non_existent", test_dir_ + "/g").ok());
   ASSERT_OK(env_->RenameFile(test_dir_ + "/f1", test_dir_ + "/g"));
-  ASSERT_EQ(Status_NotFound(), env_->FileExists(test_dir_ + "/f1"));
+  ASSERT_TRUE(Status_NotFound().eq(env_->FileExists(test_dir_ + "/f1")));
   ASSERT_OK(env_->FileExists(test_dir_ + "/g"));
   ASSERT_OK(env_->GetFileSize(test_dir_ + "/g", &file_size));
   ASSERT_EQ(3U, file_size);
@@ -228,7 +228,7 @@ TEST_P(EnvBasicTestWithParam, Basics) {
   // Check that deleting works.
   ASSERT_NOK(env_->DeleteFile(test_dir_ + "/non_existent"));
   ASSERT_OK(env_->DeleteFile(test_dir_ + "/g"));
-  ASSERT_EQ(Status_NotFound(), env_->FileExists(test_dir_ + "/g"));
+  ASSERT_TRUE(Status_NotFound().eq(env_->FileExists(test_dir_ + "/g")));
   ASSERT_OK(env_->GetChildren(test_dir_, &children));
   ASSERT_EQ(0U, children.size());
   Status s = env_->GetChildren(test_dir_ + "/non_existent", &children);
@@ -334,7 +334,7 @@ TEST_P(EnvMoreTestWithParam, MakeDir) {
   ASSERT_TRUE(!env_->CreateDir(test_dir_ + "/j").ok());
   ASSERT_OK(env_->CreateDirIfMissing(test_dir_ + "/j"));
   ASSERT_OK(env_->DeleteDir(test_dir_ + "/j"));
-  ASSERT_EQ(Status_NotFound(), env_->FileExists(test_dir_ + "/j"));
+  ASSERT_TRUE(Status_NotFound().eq(env_->FileExists(test_dir_ + "/j")));
 }
 
 TEST_P(EnvMoreTestWithParam, GetChildren) {

--- a/rocksdb-cxx/include/rocksdb/status.h
+++ b/rocksdb-cxx/include/rocksdb/status.h
@@ -39,7 +39,8 @@ class Status {
   Status(Status&& s) noexcept;
   Status& operator=(Status&& s) noexcept;
   bool operator==(const Status& rhs) const;
-  bool operator!=(const Status& rhs) const;
+
+  bool eq(const Status& s) const;
 
   Code code() const;
   SubCode subcode() const;

--- a/rocksdb-cxx/include/rocksdb/status.h
+++ b/rocksdb-cxx/include/rocksdb/status.h
@@ -38,7 +38,6 @@ class Status {
   Status& operator=(const Status& s);
   Status(Status&& s) noexcept;
   Status& operator=(Status&& s) noexcept;
-  bool operator==(const Status& rhs) const;
 
   bool eq(const Status& s) const;
 

--- a/rocksdb-cxx/include/rocksdb/utilities/env_mirror.h
+++ b/rocksdb-cxx/include/rocksdb/utilities/env_mirror.h
@@ -60,13 +60,13 @@ class EnvMirror : public EnvWrapper {
     std::unique_ptr<Directory> br;
     Status as = a_->NewDirectory(name, result);
     Status bs = b_->NewDirectory(name, &br);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status FileExists(const std::string& f) override {
     Status as = a_->FileExists(f);
     Status bs = b_->FileExists(f);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
 #if defined(_MSC_VER)
@@ -79,7 +79,7 @@ class EnvMirror : public EnvWrapper {
     std::vector<std::string> ar, br;
     Status as = a_->GetChildren(dir, &ar);
     Status bs = b_->GetChildren(dir, &br);
-    assert(as == bs);
+    assert(as.eq(bs));
     std::sort(ar.begin(), ar.end());
     std::sort(br.begin(), br.end());
     if (!as.ok() || ar != br) {
@@ -94,32 +94,32 @@ class EnvMirror : public EnvWrapper {
   Status DeleteFile(const std::string& f) override {
     Status as = a_->DeleteFile(f);
     Status bs = b_->DeleteFile(f);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status CreateDir(const std::string& d) override {
     Status as = a_->CreateDir(d);
     Status bs = b_->CreateDir(d);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status CreateDirIfMissing(const std::string& d) override {
     Status as = a_->CreateDirIfMissing(d);
     Status bs = b_->CreateDirIfMissing(d);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status DeleteDir(const std::string& d) override {
     Status as = a_->DeleteDir(d);
     Status bs = b_->DeleteDir(d);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status GetFileSize(const std::string& f, uint64_t* s) override {
     uint64_t asize, bsize;
     Status as = a_->GetFileSize(f, &asize);
     Status bs = b_->GetFileSize(f, &bsize);
-    assert(as == bs);
+    assert(as.eq(bs));
     assert(!as.ok() || asize == bsize);
     *s = asize;
     return as;
@@ -130,7 +130,7 @@ class EnvMirror : public EnvWrapper {
     uint64_t amtime, bmtime;
     Status as = a_->GetFileModificationTime(fname, &amtime);
     Status bs = b_->GetFileModificationTime(fname, &bmtime);
-    assert(as == bs);
+    assert(as.eq(bs));
     assert(!as.ok() || amtime - bmtime < 10000 || bmtime - amtime < 10000);
     *file_mtime = amtime;
     return as;
@@ -139,14 +139,14 @@ class EnvMirror : public EnvWrapper {
   Status RenameFile(const std::string& s, const std::string& t) override {
     Status as = a_->RenameFile(s, t);
     Status bs = b_->RenameFile(s, t);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
 
   Status LinkFile(const std::string& s, const std::string& t) override {
     Status as = a_->LinkFile(s, t);
     Status bs = b_->LinkFile(s, t);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
 
@@ -160,7 +160,7 @@ class EnvMirror : public EnvWrapper {
     FileLock *al, *bl;
     Status as = a_->LockFile(f, &al);
     Status bs = b_->LockFile(f, &bl);
-    assert(as == bs);
+    assert(as.eq(bs));
     if (as.ok()) *l = new FileLockMirror(al, bl);
     return as;
   }
@@ -169,7 +169,7 @@ class EnvMirror : public EnvWrapper {
     FileLockMirror* ml = static_cast<FileLockMirror*>(l);
     Status as = a_->UnlockFile(ml->a_);
     Status bs = b_->UnlockFile(ml->b_);
-    assert(as == bs);
+    assert(as.eq(bs));
     delete ml;
     return as;
   }

--- a/rocksdb-cxx/logging/auto_roll_logger_test.cc
+++ b/rocksdb-cxx/logging/auto_roll_logger_test.cc
@@ -224,7 +224,7 @@ TEST_F(AutoRollLoggerTest, RollLogFileByTime) {
 
   InitTestDb();
   // -- Test the existence of file during the server restart.
-  ASSERT_EQ(Status_NotFound(), default_env->FileExists(kLogFile));
+  ASSERT_TRUE(Status_NotFound().eq(default_env->FileExists(kLogFile)));
   AutoRollLogger logger(default_env->GetFileSystem(), nsc, kTestDir, "",
                         log_size, time, keep_log_file_num);
   ASSERT_OK(default_env->FileExists(kLogFile));
@@ -560,7 +560,7 @@ TEST_F(AutoRollLoggerTest, Close) {
     ROCKS_LOG_FATAL(&logger, "%s", kSampleMessage.c_str());
     log_lines += InfoLogLevel::HEADER_LEVEL - log_level + 1;
   }
-  ASSERT_EQ(logger.Close(), Status_OK());
+  ASSERT_TRUE(logger.Close().eq(Status_OK()));
 
   std::ifstream inFile(AutoRollLoggerTest::kLogFile.c_str());
   size_t lines = std::count(std::istreambuf_iterator<char>(inFile),

--- a/rocksdb-cxx/logging/env_logger_test.cc
+++ b/rocksdb-cxx/logging/env_logger_test.cc
@@ -57,11 +57,11 @@ const std::string EnvLoggerTest::kLogFile = test::PerThreadDBPath("log_file");
 
 TEST_F(EnvLoggerTest, EmptyLogFile) {
   auto logger = CreateLogger();
-  ASSERT_EQ(logger->Close(), Status_OK());
+  ASSERT_TRUE(logger->Close().eq(Status_OK()));
 
   // Check the size of the log file.
   uint64_t file_size;
-  ASSERT_EQ(env_->GetFileSize(kLogFile, &file_size), Status_OK());
+  ASSERT_TRUE(env_->GetFileSize(kLogFile, &file_size).eq(Status_OK()));
   ASSERT_EQ(file_size, 0);
   DeleteLogFile();
 }
@@ -75,7 +75,7 @@ TEST_F(EnvLoggerTest, LogMultipleLines) {
 
   // Flush the logs.
   logger->Flush();
-  ASSERT_EQ(logger->Close(), Status_OK());
+  ASSERT_TRUE(logger->Close().eq(Status_OK()));
 
   // Validate whether the log file has 'kNumIter' number of lines.
   ASSERT_EQ(test::GetLinesCount(kLogFile, kSampleMessage), kNumIter);
@@ -90,7 +90,7 @@ TEST_F(EnvLoggerTest, Overwrite) {
     const int kNumIter = 10;
     WriteLogs(logger, kSampleMessage, kNumIter);
 
-    ASSERT_EQ(logger->Close(), Status_OK());
+    ASSERT_TRUE(logger->Close().eq(Status_OK()));
 
     // Validate whether the log file has 'kNumIter' number of lines.
     ASSERT_EQ(test::GetLinesCount(kLogFile, kSampleMessage), kNumIter);
@@ -102,10 +102,10 @@ TEST_F(EnvLoggerTest, Overwrite) {
 
     // File should be empty.
     uint64_t file_size;
-    ASSERT_EQ(env_->GetFileSize(kLogFile, &file_size), Status_OK());
+    ASSERT_TRUE(env_->GetFileSize(kLogFile, &file_size).eq(Status_OK()));
     ASSERT_EQ(file_size, 0);
     ASSERT_EQ(logger->GetLogFileSize(), 0);
-    ASSERT_EQ(logger->Close(), Status_OK());
+    ASSERT_TRUE(logger->Close().eq(Status_OK()));
   }
   DeleteLogFile();
 }
@@ -117,7 +117,7 @@ TEST_F(EnvLoggerTest, Close) {
   const int kNumIter = 10;
   WriteLogs(logger, kSampleMessage, kNumIter);
 
-  ASSERT_EQ(logger->Close(), Status_OK());
+  ASSERT_TRUE(logger->Close().eq(Status_OK()));
 
   // Validate whether the log file has 'kNumIter' number of lines.
   ASSERT_EQ(test::GetLinesCount(kLogFile, kSampleMessage), kNumIter);
@@ -146,7 +146,7 @@ TEST_F(EnvLoggerTest, ConcurrentLogging) {
     th.join();
   }
 
-  ASSERT_EQ(logger->Close(), Status_OK());
+  ASSERT_TRUE(logger->Close().eq(Status_OK()));
 
   // Verfiy the log file.
   ASSERT_EQ(test::GetLinesCount(kLogFile, kSampleMessage),

--- a/rocksdb-cxx/table/merging_iterator.cc
+++ b/rocksdb-cxx/table/merging_iterator.cc
@@ -1301,7 +1301,7 @@ void MergingIterator::SwitchToForward() {
       // request for retrieval of data blocks has been submitted. So it should
       // return at this point and Seek should be called again to retrieve the
       // requested block and add the child to min heap.
-      if (child.iter.status() == Status_TryAgain()) {
+      if (child.iter.status().eq(Status_TryAgain())) {
         continue;
       }
       if (child.iter.Valid() && comparator_->Equal(target, child.iter.key())) {
@@ -1313,7 +1313,7 @@ void MergingIterator::SwitchToForward() {
   }
 
   for (auto& child : children_) {
-    if (child.iter.status() == Status_TryAgain()) {
+    if (child.iter.status().eq(Status_TryAgain())) {
       child.iter.Seek(target);
       if (child.iter.Valid() && comparator_->Equal(target, child.iter.key())) {
         assert(child.iter.status().ok());

--- a/rocksdb-cxx/tools/block_cache_analyzer/block_cache_trace_analyzer_test.cc
+++ b/rocksdb-cxx/tools/block_cache_analyzer/block_cache_trace_analyzer_test.cc
@@ -666,7 +666,7 @@ TEST_F(BlockCacheTracerTest, MixedBlocks) {
         /*is_block_cache_human_readable_trace=*/false,
         /*simulator=*/nullptr);
     // The analyzer ends when it detects an incomplete access record.
-    ASSERT_EQ(Status_Incomplete(""), analyzer.Analyze());
+    ASSERT_TRUE(Status_Incomplete("").eq(analyzer.Analyze()));
     const uint64_t expected_num_cfs = 1;
     std::vector<uint64_t> expected_fds{kSSTStoringOddKeys, kSSTStoringEvenKeys};
     const std::vector<TraceType> expected_types{
@@ -775,7 +775,7 @@ TEST_F(BlockCacheTracerTest, MultiGetWithNullReferenceKey) {
         /*is_human_readable_trace_file=*/false,
         /*cache_simulator=*/nullptr);
     // The analyzer ends when it detects an incomplete access record.
-    ASSERT_EQ(Status_Incomplete(""), analyzer.Analyze());
+    ASSERT_TRUE(Status_Incomplete("").eq(analyzer.Analyze()));
 
     ASSERT_OK(env_->DeleteFile(human_readable_trace_file_path));
   }

--- a/rocksdb-cxx/trace_replay/trace_replay.cc
+++ b/rocksdb-cxx/trace_replay/trace_replay.cc
@@ -72,7 +72,7 @@ Status TracerHelper::ParseTraceHeader(const Trace& header, int* trace_version,
   db_v_str = s_vec[2].substr(17);
 
   Status s = ParseVersionStr(t_v_str, trace_version);
-  if (s != Status_OK()) {
+  if (!s.eq(Status_OK())) {
     return s;
   }
   s = ParseVersionStr(db_v_str, db_version);

--- a/rocksdb-cxx/util/status.cc
+++ b/rocksdb-cxx/util/status.cc
@@ -406,8 +406,8 @@ bool Status::operator==(const Status& rhs) const {
     return rs_status_.eq(rhs.rs_status_);
 }
 
-bool Status::operator!=(const Status& rhs) const {
-    return !rs_status_.eq(rhs.rs_status_);
+bool Status::eq(const Status& s) const {
+    return rs_status_.eq(s.rs_status_);
 }
 
 std::unique_ptr<std::string> Status_CopyState(const std::string& s) {

--- a/rocksdb-cxx/util/status.cc
+++ b/rocksdb-cxx/util/status.cc
@@ -402,10 +402,6 @@ Status& Status::operator=(Status&& s) noexcept {
     return *this;
 }
 
-bool Status::operator==(const Status& rhs) const {
-    return rs_status_.eq(rhs.rs_status_);
-}
-
 bool Status::eq(const Status& s) const {
     return rs_status_.eq(s.rs_status_);
 }

--- a/rocksdb-cxx/utilities/backup/backup_engine_test.cc
+++ b/rocksdb-cxx/utilities/backup/backup_engine_test.cc
@@ -2568,7 +2568,7 @@ TEST_F(BackupEngineTest, DeleteTmpFiles) {
       }
       CloseDBAndBackupEngine();
       for (std::string file_or_dir : tmp_files_and_dirs) {
-        if (file_manager_->FileExists(file_or_dir) != Status_NotFound()) {
+        if (!file_manager_->FileExists(file_or_dir).eq(Status_NotFound())) {
           FAIL() << file_or_dir << " was expected to be deleted." << cleanup_fn;
         }
       }

--- a/rocksdb-cxx/utilities/backup/backup_engine_test.cc
+++ b/rocksdb-cxx/utilities/backup/backup_engine_test.cc
@@ -1274,8 +1274,8 @@ TEST_F(BackupEngineTest, NoDoubleCopy_And_AutoGC) {
   ASSERT_OK(test_backup_env_->FileExists(backupdir_ + "/shared/00010.sst"));
 
   // 00011.sst was only in backup 1, should be deleted
-  ASSERT_EQ(Status_NotFound(),
-            test_backup_env_->FileExists(backupdir_ + "/shared/00011.sst"));
+  ASSERT_TRUE(Status_NotFound().eq(
+            test_backup_env_->FileExists(backupdir_ + "/shared/00011.sst")));
   ASSERT_OK(test_backup_env_->FileExists(backupdir_ + "/shared/00015.sst"));
 
   // MANIFEST file size should be only 100
@@ -1311,16 +1311,16 @@ TEST_F(BackupEngineTest, NoDoubleCopy_And_AutoGC) {
 
   // Make sure dangling sst file has been removed (somewhere along this
   // process). GarbageCollect should not be needed.
-  ASSERT_EQ(Status_NotFound(),
-            test_backup_env_->FileExists(backupdir_ + "/shared/00015.sst"));
+  ASSERT_TRUE(Status_NotFound().eq(
+            test_backup_env_->FileExists(backupdir_ + "/shared/00015.sst")));
   ASSERT_OK(test_backup_env_->FileExists(backupdir_ + "/shared/00017.sst"));
   ASSERT_OK(test_backup_env_->FileExists(backupdir_ + "/shared/00019.sst"));
 
   // Now actually purge a good one
   ASSERT_OK(backup_engine_->PurgeOldBackups(1));
 
-  ASSERT_EQ(Status_NotFound(),
-            test_backup_env_->FileExists(backupdir_ + "/shared/00017.sst"));
+  ASSERT_TRUE(Status_NotFound().eq(
+            test_backup_env_->FileExists(backupdir_ + "/shared/00017.sst")));
   ASSERT_OK(test_backup_env_->FileExists(backupdir_ + "/shared/00019.sst"));
 
   CloseDBAndBackupEngine();
@@ -1407,22 +1407,14 @@ TEST_F(BackupEngineTest, CorruptionsTest) {
   ASSERT_OK(backup_engine_->DeleteBackup(2));
   // Should not be needed anymore with auto-GC on DeleteBackup
   //(void)backup_engine_->GarbageCollect();
-  ASSERT_EQ(Status_NotFound(),
-            file_manager_->FileExists(backupdir_ + "/meta/5"));
-  ASSERT_EQ(Status_NotFound(),
-            file_manager_->FileExists(backupdir_ + "/private/5"));
-  ASSERT_EQ(Status_NotFound(),
-            file_manager_->FileExists(backupdir_ + "/meta/4"));
-  ASSERT_EQ(Status_NotFound(),
-            file_manager_->FileExists(backupdir_ + "/private/4"));
-  ASSERT_EQ(Status_NotFound(),
-            file_manager_->FileExists(backupdir_ + "/meta/3"));
-  ASSERT_EQ(Status_NotFound(),
-            file_manager_->FileExists(backupdir_ + "/private/3"));
-  ASSERT_EQ(Status_NotFound(),
-            file_manager_->FileExists(backupdir_ + "/meta/2"));
-  ASSERT_EQ(Status_NotFound(),
-            file_manager_->FileExists(backupdir_ + "/private/2"));
+  ASSERT_TRUE(Status_NotFound().eq(file_manager_->FileExists(backupdir_ + "/meta/5")));
+  ASSERT_TRUE(Status_NotFound().eq(file_manager_->FileExists(backupdir_ + "/private/5")));
+  ASSERT_TRUE(Status_NotFound().eq(file_manager_->FileExists(backupdir_ + "/meta/4")));
+  ASSERT_TRUE(Status_NotFound().eq(file_manager_->FileExists(backupdir_ + "/private/4")));
+  ASSERT_TRUE(Status_NotFound().eq(file_manager_->FileExists(backupdir_ + "/meta/3")));
+  ASSERT_TRUE(Status_NotFound().eq(file_manager_->FileExists(backupdir_ + "/private/3")));
+  ASSERT_TRUE(Status_NotFound().eq(file_manager_->FileExists(backupdir_ + "/meta/2")));
+  ASSERT_TRUE(Status_NotFound().eq(file_manager_->FileExists(backupdir_ + "/private/2")));
   CloseBackupEngine();
   AssertBackupConsistency(0, 0, keys_iteration * 1, keys_iteration * 5);
 

--- a/rocksdb-cxx/utilities/checkpoint/checkpoint_test.cc
+++ b/rocksdb-cxx/utilities/checkpoint/checkpoint_test.cc
@@ -443,16 +443,14 @@ TEST_F(CheckpointTest, ExportColumnFamilyNegativeTest) {
 
   // Export onto existing directory
   ASSERT_OK(env_->CreateDirIfMissing(export_path_));
-  ASSERT_EQ(checkpoint->ExportColumnFamily(db_->DefaultColumnFamily(),
-                                           export_path_, &metadata_),
-            Status_InvalidArgument("Specified export_dir exists"));
+  ASSERT_TRUE(checkpoint->ExportColumnFamily(db_->DefaultColumnFamily(), export_path_, &metadata_).eq(
+            Status_InvalidArgument("Specified export_dir exists")));
   ASSERT_OK(DestroyDir(env_, export_path_));
 
   // Export with invalid directory specification
   export_path_ = "";
-  ASSERT_EQ(checkpoint->ExportColumnFamily(db_->DefaultColumnFamily(),
-                                           export_path_, &metadata_),
-            Status_InvalidArgument("Specified export_dir invalid"));
+  ASSERT_TRUE(checkpoint->ExportColumnFamily(db_->DefaultColumnFamily(), export_path_, &metadata_).eq(
+            Status_InvalidArgument("Specified export_dir invalid")));
   delete checkpoint;
 }
 

--- a/rocksdb-cxx/utilities/env_mirror.cc
+++ b/rocksdb-cxx/utilities/env_mirror.cc
@@ -23,7 +23,7 @@ class SequentialFileMirror : public SequentialFile {
   Status Read(size_t n, Slice* result, char* scratch) override {
     Slice aslice;
     Status as = a_->Read(n, &aslice, scratch);
-    if (as == Status_OK()) {
+    if (as.eq(Status_OK())) {
       char* bscratch = new char[n];
       Slice bslice;
 #ifndef NDEBUG
@@ -33,7 +33,7 @@ class SequentialFileMirror : public SequentialFile {
       while (left) {
         Status bs = b_->Read(left, &bslice, bscratch);
 #ifndef NDEBUG
-        assert(as == bs);
+        assert(as.eq(bs));
         assert(memcmp(bscratch, scratch + off, bslice.size()) == 0);
         off += bslice.size();
 #endif
@@ -43,7 +43,7 @@ class SequentialFileMirror : public SequentialFile {
       *result = aslice;
     } else {
       Status bs = b_->Read(n, result, scratch);
-      assert(as == bs);
+      assert(as.eq(bs));
     }
     return as;
   }
@@ -51,13 +51,13 @@ class SequentialFileMirror : public SequentialFile {
   Status Skip(uint64_t n) override {
     Status as = a_->Skip(n);
     Status bs = b_->Skip(n);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status InvalidateCache(size_t offset, size_t length) override {
     Status as = a_->InvalidateCache(offset, length);
     Status bs = b_->InvalidateCache(offset, length);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   };
 };
@@ -71,14 +71,14 @@ class RandomAccessFileMirror : public RandomAccessFile {
   Status Read(uint64_t offset, size_t n, Slice* result,
               char* scratch) const override {
     Status as = a_->Read(offset, n, result, scratch);
-    if (as == Status_OK()) {
+    if (as.eq(Status_OK())) {
       char* bscratch = new char[n];
       Slice bslice;
       size_t off = 0;
       size_t left = result->size();
       while (left) {
         Status bs = b_->Read(offset + off, left, &bslice, bscratch);
-        assert(as == bs);
+        assert(as.eq(bs));
         assert(memcmp(bscratch, scratch + off, bslice.size()) == 0);
         off += bslice.size();
         left -= bslice.size();
@@ -86,7 +86,7 @@ class RandomAccessFileMirror : public RandomAccessFile {
       delete[] bscratch;
     } else {
       Status bs = b_->Read(offset, n, result, scratch);
-      assert(as == bs);
+      assert(as.eq(bs));
     }
     return as;
   }
@@ -107,7 +107,7 @@ class WritableFileMirror : public WritableFile {
   Status Append(const Slice& data) override {
     Status as = a_->Append(data);
     Status bs = b_->Append(data);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status Append(const Slice& data,
@@ -117,7 +117,7 @@ class WritableFileMirror : public WritableFile {
   Status PositionedAppend(const Slice& data, uint64_t offset) override {
     Status as = a_->PositionedAppend(data, offset);
     Status bs = b_->PositionedAppend(data, offset);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status PositionedAppend(
@@ -128,31 +128,31 @@ class WritableFileMirror : public WritableFile {
   Status Truncate(uint64_t size) override {
     Status as = a_->Truncate(size);
     Status bs = b_->Truncate(size);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status Close() override {
     Status as = a_->Close();
     Status bs = b_->Close();
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status Flush() override {
     Status as = a_->Flush();
     Status bs = b_->Flush();
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status Sync() override {
     Status as = a_->Sync();
     Status bs = b_->Sync();
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status Fsync() override {
     Status as = a_->Fsync();
     Status bs = b_->Fsync();
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   bool IsSyncThreadSafe() const override {
@@ -185,7 +185,7 @@ class WritableFileMirror : public WritableFile {
   Status InvalidateCache(size_t offset, size_t length) override {
     Status as = a_->InvalidateCache(offset, length);
     Status bs = b_->InvalidateCache(offset, length);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
 
@@ -193,13 +193,13 @@ class WritableFileMirror : public WritableFile {
   Status Allocate(uint64_t offset, uint64_t length) override {
     Status as = a_->Allocate(offset, length);
     Status bs = b_->Allocate(offset, length);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
   Status RangeSync(uint64_t offset, uint64_t nbytes) override {
     Status as = a_->RangeSync(offset, nbytes);
     Status bs = b_->RangeSync(offset, nbytes);
-    assert(as == bs);
+    assert(as.eq(bs));
     return as;
   }
 };
@@ -213,7 +213,7 @@ Status EnvMirror::NewSequentialFile(const std::string& f,
   SequentialFileMirror* mf = new SequentialFileMirror(f);
   Status as = a_->NewSequentialFile(f, &mf->a_, options);
   Status bs = b_->NewSequentialFile(f, &mf->b_, options);
-  assert(as == bs);
+  assert(as.eq(bs));
   if (as.ok())
     r->reset(mf);
   else
@@ -230,7 +230,7 @@ Status EnvMirror::NewRandomAccessFile(const std::string& f,
   RandomAccessFileMirror* mf = new RandomAccessFileMirror(f);
   Status as = a_->NewRandomAccessFile(f, &mf->a_, options);
   Status bs = b_->NewRandomAccessFile(f, &mf->b_, options);
-  assert(as == bs);
+  assert(as.eq(bs));
   if (as.ok())
     r->reset(mf);
   else
@@ -245,7 +245,7 @@ Status EnvMirror::NewWritableFile(const std::string& f,
   WritableFileMirror* mf = new WritableFileMirror(f, options);
   Status as = a_->NewWritableFile(f, &mf->a_, options);
   Status bs = b_->NewWritableFile(f, &mf->b_, options);
-  assert(as == bs);
+  assert(as.eq(bs));
   if (as.ok())
     r->reset(mf);
   else
@@ -262,7 +262,7 @@ Status EnvMirror::ReuseWritableFile(const std::string& fname,
   WritableFileMirror* mf = new WritableFileMirror(fname, options);
   Status as = a_->ReuseWritableFile(fname, old_fname, &mf->a_, options);
   Status bs = b_->ReuseWritableFile(fname, old_fname, &mf->b_, options);
-  assert(as == bs);
+  assert(as.eq(bs));
   if (as.ok())
     r->reset(mf);
   else

--- a/rocksdb-cxx/utilities/transactions/transaction_test.cc
+++ b/rocksdb-cxx/utilities/transactions/transaction_test.cc
@@ -939,7 +939,7 @@ TEST_P(TransactionTest, CommitTimeBatchFailTest) {
 
   // fails due to non-empty commit-time batch
   s = txn1->Commit();
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   delete txn1;
 }
@@ -1056,7 +1056,7 @@ TEST_P(TransactionTest, SimpleTwoPhaseTransactionTest) {
 
     // we already committed
     s = txn->Commit();
-    ASSERT_EQ(s, Status_InvalidArgument());
+    ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
     // no longer is prepared results
     db->GetAllPreparedTransactions(&prepared_trans);
@@ -1129,15 +1129,15 @@ TEST_P(TransactionTest, TwoPhaseNameTest) {
 
   // cant prepare txn without name
   s = txn1->Prepare();
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   // name too short
   s = txn1->SetName("");
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   // name too long
   s = txn1->SetName(std::string(513, 'x'));
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   // valid set name
   s = txn1->SetName("name1");
@@ -1145,11 +1145,11 @@ TEST_P(TransactionTest, TwoPhaseNameTest) {
 
   // cant have duplicate name
   s = txn2->SetName("name1");
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   // shouldn't be able to prepare
   s = txn2->Prepare();
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   // valid name set
   s = txn2->SetName("name2");
@@ -1157,7 +1157,7 @@ TEST_P(TransactionTest, TwoPhaseNameTest) {
 
   // cant reset name
   s = txn2->SetName("name3");
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   ASSERT_EQ(txn1->GetName(), "name1");
   ASSERT_EQ(txn2->GetName(), "name2");
@@ -1167,7 +1167,7 @@ TEST_P(TransactionTest, TwoPhaseNameTest) {
 
   // can't rename after prepare
   s = txn1->SetName("name4");
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   ASSERT_OK(txn1->Rollback());
   ASSERT_OK(txn2->Rollback());
@@ -1270,7 +1270,7 @@ TEST_P(TransactionStressTest, TwoPhaseExpirationTest) {
   ASSERT_OK(s);
 
   s = txn2->Prepare();
-  ASSERT_EQ(s, Status_Expired());
+  ASSERT_TRUE(s.eq(Status_Expired()));
 
   delete txn1;
   delete txn2;
@@ -1336,11 +1336,11 @@ TEST_P(TransactionTest, TwoPhaseRollbackTest) {
 
   // make commit
   s = txn->Commit();
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   // try rollback again
   s = txn->Rollback();
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   delete txn;
 }
@@ -1435,7 +1435,7 @@ TEST_P(TransactionTest, PersistentTwoPhaseTransactionTest) {
 
   // we already committed
   s = txn->Commit();
-  ASSERT_EQ(s, Status_InvalidArgument());
+  ASSERT_TRUE(s.eq(Status_InvalidArgument()));
 
   // no longer is prepared results
   prepared_trans.clear();
@@ -1616,7 +1616,7 @@ TEST_P(TransactionStressTest, TwoPhaseLongPrepareTest) {
 
   // verify data txn data
   s = db->Get(read_options, "foo", &value);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(value, "bar");
 
   // verify non txn data
@@ -1624,7 +1624,7 @@ TEST_P(TransactionStressTest, TwoPhaseLongPrepareTest) {
     std::string key(i, 'k');
     std::string val(1000, 'v');
     s = db->Get(read_options, key, &value);
-    ASSERT_EQ(s, Status_OK());
+    ASSERT_TRUE(s.eq(Status_OK()));
     ASSERT_EQ(value, val);
   }
 
@@ -1673,7 +1673,7 @@ TEST_P(TransactionTest, TwoPhaseSequenceTest) {
 
   // value is now available
   s = db->Get(read_options, "foo4", &value);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(value, "bar4");
 }
 #endif  // !defined(ROCKSDB_VALGRIND_RUN) || defined(ROCKSDB_FULL_VALGRIND_RUN)
@@ -1716,7 +1716,7 @@ TEST_P(TransactionTest, TwoPhaseDoubleRecoveryTest) {
   ASSERT_OK(s);
 
   s = db->Get(read_options, "foo", &value);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(value, "bar");
 
   delete txn;
@@ -1743,11 +1743,11 @@ TEST_P(TransactionTest, TwoPhaseDoubleRecoveryTest) {
 
   // value is now available
   s = db->Get(read_options, "foo", &value);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(value, "bar");
 
   s = db->Get(read_options, "foo2", &value);
-  ASSERT_EQ(s, Status_OK());
+  ASSERT_TRUE(s.eq(Status_OK()));
   ASSERT_EQ(value, "bar2");
 }
 

--- a/rocksdb-cxx/utilities/transactions/write_prepared_transaction_test.cc
+++ b/rocksdb-cxx/utilities/transactions/write_prepared_transaction_test.cc
@@ -2191,7 +2191,7 @@ void ASSERT_SAME(ReadOptions roptions, TransactionDB* db, Status exp_s,
   Status s = Status_new();
   PinnableSlice v;
   s = db->Get(roptions, db->DefaultColumnFamily(), key, &v);
-  ASSERT_EQ(exp_s, s);
+  ASSERT_TRUE(exp_s.eq(s));
   ASSERT_TRUE(s.ok() || s.IsNotFound());
   if (s.ok()) {
     ASSERT_TRUE(exp_v == v);
@@ -2204,7 +2204,7 @@ void ASSERT_SAME(ReadOptions roptions, TransactionDB* db, Status exp_s,
   ASSERT_EQ(1, values.size());
   ASSERT_EQ(1, s_vec.size());
   s = s_vec[0];
-  ASSERT_EQ(exp_s, s);
+  ASSERT_TRUE(exp_s.eq(s));
   ASSERT_TRUE(s.ok() || s.IsNotFound());
   if (s.ok()) {
     ASSERT_TRUE(exp_v == values[0]);


### PR DESCRIPTION
Removed the `==`and `!=`operators from Status and introduced the `bool eq(const Status&) const` method. This will help with the rust migration as the rust struct will not autogenerate == or !=.