### PR TITLE
Start porting filename.cc

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
         include:
         - os: ubuntu-latest
           deps: sudo apt-get install -y ninja-build libgflags-dev
-          cpus: 2
+          cpus: 4
         - os: macos-13
           deps: brew install ninja gflags
           cpus: 4

--- a/build.rs
+++ b/build.rs
@@ -338,6 +338,7 @@ fn main() {
         "src/cache.rs",
         "src/compression_type.rs",
         "src/env.rs",
+        "src/filename.rs",
         "src/hash.rs",
         "src/lib.rs",
         "src/port_defs.rs",

--- a/rocksdb-cxx/CMakeLists.txt
+++ b/rocksdb-cxx/CMakeLists.txt
@@ -1111,7 +1111,7 @@ configure_file(util/build_version.cc.in ${BUILD_VERSION_CC} @ONLY)
 corrosion_import_crate(MANIFEST_PATH ../Cargo.toml)
 corrosion_set_env_vars(rocksdb-rs SKIP_BUILD_SCRIPT=1)
 corrosion_add_cxxbridge_custom(rocksdb-rs-cxx CRATE rocksdb-rs
-        FILES cache.rs compression_type.rs env.rs hash.rs lib.rs port_defs.rs slice.rs status.rs unique_id.rs)
+        FILES cache.rs compression_type.rs env.rs filename.rs hash.rs lib.rs port_defs.rs slice.rs status.rs unique_id.rs)
 target_include_directories(rocksdb-rs-cxx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_library(${ROCKSDB_STATIC_LIB} STATIC ${SOURCES} ${BUILD_VERSION_CC})

--- a/rocksdb-cxx/db/corruption_test.cc
+++ b/rocksdb-cxx/db/corruption_test.cc
@@ -295,7 +295,7 @@ class CorruptionTest : public testing::Test {
 
   void CorruptFileWithTruncation(FileType file, uint64_t number,
                                  uint64_t bytes_to_truncate = 0) {
-    std::string path;
+    rust::String path;
     switch (file) {
       case FileType::kWalFile:
         path = LogFileName(dbname_, number);

--- a/rocksdb-cxx/db/db_impl/db_impl.cc
+++ b/rocksdb-cxx/db/db_impl/db_impl.cc
@@ -4830,7 +4830,7 @@ Status DestroyDB(const std::string& dbname, const Options& options,
       for (const auto& file : walDirFiles) {
         if (ParseFileName(file, &number, &type) && type == kWalFile) {
           Status del =
-              DeleteDBFile(&soptions, LogFileName(soptions.wal_dir, number),
+              DeleteDBFile(&soptions, static_cast<std::string>(LogFileName(soptions.wal_dir, number)),
                            soptions.wal_dir, /*force_bg=*/false,
                            /*force_fg=*/!wal_in_db_path);
           if (!del.ok() && result.ok()) {

--- a/rocksdb-cxx/db/db_impl/db_impl_open.cc
+++ b/rocksdb-cxx/db/db_impl/db_impl_open.cc
@@ -698,7 +698,7 @@ Status DBImpl::Recover(
               "existing log file: ",
               file);
         } else {
-          wal_files[number] = LogFileName(wal_dir, number);
+          wal_files[number] = static_cast<std::string>(LogFileName(wal_dir, number));
         }
       }
     }
@@ -1123,7 +1123,7 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& wal_numbers,
     versions_->MarkFileNumberUsed(wal_number);
     // Open the log file
     std::string fname =
-        LogFileName(immutable_db_options_.GetWalDir(), wal_number);
+        static_cast<std::string>(LogFileName(immutable_db_options_.GetWalDir(), wal_number));
 
     ROCKS_LOG_INFO(immutable_db_options_.info_log,
                    "Recovering log #%" PRIu64 " mode %d", wal_number,
@@ -1506,7 +1506,7 @@ Status DBImpl::GetLogSizeAndMaybeTruncate(uint64_t wal_number, bool truncate,
                                           LogFileNumberSize* log_ptr) {
   LogFileNumberSize log(wal_number);
   std::string fname =
-      LogFileName(immutable_db_options_.GetWalDir(), wal_number);
+      static_cast<std::string>(LogFileName(immutable_db_options_.GetWalDir(), wal_number));
   Status s = Status_new();
   // This gets the appear size of the wals, not including preallocated space.
   s = env_->GetFileSize(fname, &log.size);
@@ -1856,13 +1856,13 @@ IOStatus DBImpl::CreateWAL(uint64_t log_file_num, uint64_t recycle_log_number,
   FileOptions opt_file_options =
       fs_->OptimizeForLogWrite(file_options_, db_options);
   std::string wal_dir = immutable_db_options_.GetWalDir();
-  std::string log_fname = LogFileName(wal_dir, log_file_num);
+  std::string log_fname = static_cast<std::string>(LogFileName(wal_dir, log_file_num));
 
   if (recycle_log_number) {
     ROCKS_LOG_INFO(immutable_db_options_.info_log,
                    "reusing log %" PRIu64 " from recycle list\n",
                    recycle_log_number);
-    std::string old_log_fname = LogFileName(wal_dir, recycle_log_number);
+    std::string old_log_fname = static_cast<std::string>(LogFileName(wal_dir, recycle_log_number));
     TEST_SYNC_POINT("DBImpl::CreateWAL:BeforeReuseWritableFile1");
     TEST_SYNC_POINT("DBImpl::CreateWAL:BeforeReuseWritableFile2");
     io_s = fs_->ReuseWritableFile(log_fname, old_log_fname, opt_file_options,

--- a/rocksdb-cxx/db/db_impl/db_impl_secondary.cc
+++ b/rocksdb-cxx/db/db_impl/db_impl_secondary.cc
@@ -145,7 +145,7 @@ Status DBImplSecondary::MaybeInitLogReader(
     // TODO: min_log_number_to_keep_2pc check needed?
     // Open the log file
     std::string fname =
-        LogFileName(immutable_db_options_.GetWalDir(), log_number);
+        static_cast<std::string>(LogFileName(immutable_db_options_.GetWalDir(), log_number));
     ROCKS_LOG_INFO(immutable_db_options_.info_log,
                    "Recovering log #%" PRIu64 " mode %d", log_number,
                    static_cast<int>(immutable_db_options_.wal_recovery_mode));

--- a/rocksdb-cxx/db/db_test_util.h
+++ b/rocksdb-cxx/db/db_test_util.h
@@ -582,6 +582,11 @@ class SpecialEnv : public EnvWrapper {
     return target()->DeleteFile(fname);
   }
 
+  virtual Status DeleteFile(const rust::String& fname) override {
+    delete_count_.fetch_add(1);
+    return target()->DeleteFile(fname);
+  }
+
   void SetMockSleep(bool enabled = true) { no_slowdown_ = enabled; }
 
   Status NewDirectory(const std::string& name,

--- a/rocksdb-cxx/db/db_wal_test.cc
+++ b/rocksdb-cxx/db/db_wal_test.cc
@@ -1512,7 +1512,7 @@ class RecoveryTestHelper {
 
     for (size_t j = kWALFileOffset; j < wal_count + kWALFileOffset; j++) {
       uint64_t current_log_number = j;
-      std::string fname = LogFileName(test->dbname_, current_log_number);
+      std::string fname = static_cast<std::string>(LogFileName(test->dbname_, current_log_number));
       std::unique_ptr<WritableFileWriter> file_writer;
       ASSERT_OK(WritableFileWriter::Create(db_options.env->GetFileSystem(),
                                            fname, file_options, &file_writer,
@@ -1569,7 +1569,7 @@ class RecoveryTestHelper {
                          const double off, const double len,
                          const int wal_file_id, const bool trunc = false) {
     Env* env = options.env;
-    std::string fname = LogFileName(test->dbname_, wal_file_id);
+    std::string fname = static_cast<std::string>(LogFileName(test->dbname_, wal_file_id));
     uint64_t size;
     ASSERT_OK(env->GetFileSize(fname, &size));
     ASSERT_GT(size, 0);
@@ -1710,7 +1710,7 @@ TEST_F(DBWALTest, kPointInTimeRecoveryCFConsistency) {
   // Record the offset at this point
   Env* env = options.env;
   uint64_t wal_file_id = dbfull()->TEST_LogfileNumber();
-  std::string fname = LogFileName(dbname_, wal_file_id);
+  std::string fname = static_cast<std::string>(LogFileName(dbname_, wal_file_id));
   uint64_t offset_to_corrupt;
   ASSERT_OK(env->GetFileSize(fname, &offset_to_corrupt));
   ASSERT_GT(offset_to_corrupt, 0);

--- a/rocksdb-cxx/db/filename_test.cc
+++ b/rocksdb-cxx/db/filename_test.cc
@@ -135,7 +135,7 @@ TEST_F(FileNameTest, Construction) {
   ASSERT_EQ(0U, number);
   ASSERT_EQ(kDBLockFile, type);
 
-  fname = LogFileName("foo", 192);
+  fname = static_cast<std::string>(LogFileName("foo", 192));
   ASSERT_EQ("foo/", std::string(fname.data(), 4));
   ASSERT_TRUE(ParseFileName(fname.c_str() + 4, &number, &type));
   ASSERT_EQ(192U, number);

--- a/rocksdb-cxx/db/job_context.h
+++ b/rocksdb-cxx/db/job_context.h
@@ -137,6 +137,8 @@ struct JobContext {
     std::string file_path;
     CandidateFileInfo(std::string name, std::string path)
         : file_name(std::move(name)), file_path(std::move(path)) {}
+    CandidateFileInfo(rust::String name, std::string path)
+        : file_name(std::move(name)), file_path(std::move(path)) {}
     bool operator==(const CandidateFileInfo& other) const {
       return file_name == other.file_name && file_path == other.file_path;
     }

--- a/rocksdb-cxx/db/repair.cc
+++ b/rocksdb-cxx/db/repair.cc
@@ -337,7 +337,7 @@ class Repairer {
     for (size_t i = 0; i < logs_.size(); i++) {
       // we should use LogFileName(wal_dir, logs_[i]) here. user might uses
       // wal_dir option.
-      std::string logname = LogFileName(wal_dir, logs_[i]);
+      rust::String logname = LogFileName(wal_dir, logs_[i]);
       Status status = ConvertLogToTable(wal_dir, logs_[i]);
       if (!status.ok()) {
         ROCKS_LOG_WARN(db_options_.info_log,
@@ -364,7 +364,7 @@ class Repairer {
     const ReadOptions read_options;
 
     // Open the log file
-    std::string logname = LogFileName(wal_dir, log);
+    std::string logname = static_cast<std::string>(LogFileName(wal_dir, log));
     const auto& fs = env_->GetFileSystem();
     std::unique_ptr<SequentialFileReader> lfile_reader;
     Status status = SequentialFileReader::Create(
@@ -777,6 +777,10 @@ class Repairer {
     Status s = env_->RenameFile(fname, new_file);
     ROCKS_LOG_INFO(db_options_.info_log, "Archiving %s: %s\n", fname.c_str(),
                    s.ToString()->c_str());
+  }
+
+  void ArchiveFile(const rust::String& fname) {
+    ArchiveFile(static_cast<std::string>(fname));
   }
 };
 

--- a/rocksdb-cxx/db/transaction_log_impl.cc
+++ b/rocksdb-cxx/db/transaction_log_impl.cc
@@ -55,7 +55,7 @@ Status TransactionLogIteratorImpl::OpenLogFile(
     fname = ArchivedLogFileName(dir_, log_file->LogNumber());
     s = fs->NewSequentialFile(fname, optimized_env_options, &file, nullptr);
   } else {
-    fname = LogFileName(dir_, log_file->LogNumber());
+    fname = static_cast<std::string>(LogFileName(dir_, log_file->LogNumber()));
     s = fs->NewSequentialFile(fname, optimized_env_options, &file, nullptr);
     if (!s.ok()) {
       //  If cannot open file in DB directory.

--- a/rocksdb-cxx/db/transaction_log_impl.h
+++ b/rocksdb-cxx/db/transaction_log_impl.h
@@ -32,7 +32,7 @@ class LogFileImpl : public LogFile {
     if (type_ == kArchivedLogFile) {
       return ArchivedLogFileName("", logNumber_);
     }
-    return LogFileName("", logNumber_);
+    return static_cast<std::string>(LogFileName("", logNumber_));
   }
 
   uint64_t LogNumber() const override { return logNumber_; }

--- a/rocksdb-cxx/db/wal_manager.cc
+++ b/rocksdb-cxx/db/wal_manager.cc
@@ -392,7 +392,7 @@ Status WalManager::ReadFirstRecord(const WalFileType type,
   }
   Status s = Status_new();
   if (type == kAliveLogFile) {
-    std::string fname = LogFileName(wal_dir_, number);
+    std::string fname = static_cast<std::string>(LogFileName(wal_dir_, number));
     s = ReadFirstLine(fname, number, sequence);
     if (!s.ok() && env_->FileExists(fname).ok()) {
       // return any error that is not caused by non-existing file

--- a/rocksdb-cxx/file/filename.cc
+++ b/rocksdb-cxx/file/filename.cc
@@ -20,8 +20,6 @@
 #include "util/stop_watch.h"
 #include "util/string_util.h"
 
-#include "rocksdb-rs/src/filename.rs.h"
-
 namespace rocksdb {
 
 const std::string kCurrentFileName = "CURRENT";
@@ -61,16 +59,6 @@ static size_t GetInfoLogPrefix(const std::string& path, char* dest, int len) {
   snprintf(dest + write_idx, len - write_idx, suffix);
   write_idx += sizeof(suffix) - 1;
   return write_idx;
-}
-
-rust::String LogFileName(const std::string& name, uint64_t number) {
-  rust::String res = rs::LogFileName(name, number);
-  return res;
-}
-
-rust::String LogFileName(uint64_t number) {
-  rust::String res = rs::LogFileName(number);
-  return res;
 }
 
 std::string BlobFileName(uint64_t number) {

--- a/rocksdb-cxx/file/filename.cc
+++ b/rocksdb-cxx/file/filename.cc
@@ -63,42 +63,31 @@ static size_t GetInfoLogPrefix(const std::string& path, char* dest, int len) {
   return write_idx;
 }
 
-static std::string MakeFileName(uint64_t number, const char* suffix) {
-  rust::String str = rs::make_file_name(number, suffix);
-  return static_cast<std::string>(str);
-}
-
-static std::string MakeFileName(const std::string& name, uint64_t number,
-                                const char* suffix) {
-  rust::String str = rs::make_file_name_full_path(name, number, suffix);
-  return static_cast<std::string>(str);
-}
-
 std::string LogFileName(const std::string& name, uint64_t number) {
   assert(number > 0);
-  return MakeFileName(name, number, "log");
+  return static_cast<std::string>(rs::make_file_name_full_path(name, number, "log"));
 }
 
 std::string LogFileName(uint64_t number) {
   assert(number > 0);
-  return MakeFileName(number, "log");
+  return static_cast<std::string>(rs::make_file_name(number, "log"));
 }
 
 std::string BlobFileName(uint64_t number) {
   assert(number > 0);
-  return MakeFileName(number, kRocksDBBlobFileExt.c_str());
+  return static_cast<std::string>(rs::make_file_name(number, kRocksDBBlobFileExt.c_str()));
 }
 
 std::string BlobFileName(const std::string& blobdirname, uint64_t number) {
   assert(number > 0);
-  return MakeFileName(blobdirname, number, kRocksDBBlobFileExt.c_str());
+  return static_cast<std::string>(rs::make_file_name_full_path(blobdirname, number, kRocksDBBlobFileExt.c_str()));
 }
 
 std::string BlobFileName(const std::string& dbname, const std::string& blob_dir,
                          uint64_t number) {
   assert(number > 0);
-  return MakeFileName(dbname + "/" + blob_dir, number,
-                      kRocksDBBlobFileExt.c_str());
+  return static_cast<std::string>(rs::make_file_name_full_path(dbname + "/" + blob_dir, number,
+                      kRocksDBBlobFileExt.c_str()));
 }
 
 std::string ArchivalDirectory(const std::string& dir) {
@@ -106,15 +95,15 @@ std::string ArchivalDirectory(const std::string& dir) {
 }
 std::string ArchivedLogFileName(const std::string& name, uint64_t number) {
   assert(number > 0);
-  return MakeFileName(name + "/" + kArchivalDirName, number, "log");
+  return static_cast<std::string>(rs::make_file_name_full_path(name + "/" + kArchivalDirName, number, "log"));
 }
 
 std::string MakeTableFileName(const std::string& path, uint64_t number) {
-  return MakeFileName(path, number, kRocksDbTFileExt.c_str());
+  return static_cast<std::string>(rs::make_file_name_full_path(path, number, kRocksDbTFileExt.c_str()));
 }
 
 std::string MakeTableFileName(uint64_t number) {
-  return MakeFileName(number, kRocksDbTFileExt.c_str());
+  return static_cast<std::string>(rs::make_file_name(number, kRocksDbTFileExt.c_str()));
 }
 
 std::string Rocks2LevelTableFileName(const std::string& fullname) {
@@ -181,7 +170,7 @@ std::string CurrentFileName(const std::string& dbname) {
 std::string LockFileName(const std::string& dbname) { return dbname + "/LOCK"; }
 
 std::string TempFileName(const std::string& dbname, uint64_t number) {
-  return MakeFileName(dbname, number, kTempFileNameSuffix.c_str());
+  return static_cast<std::string>(rs::make_file_name_full_path(dbname, number, kTempFileNameSuffix.c_str()));
 }
 
 InfoLogPrefix::InfoLogPrefix(bool has_log_dir,

--- a/rocksdb-cxx/file/filename.cc
+++ b/rocksdb-cxx/file/filename.cc
@@ -20,6 +20,8 @@
 #include "util/stop_watch.h"
 #include "util/string_util.h"
 
+#include "rocksdb-rs/src/filename.rs.h"
+
 namespace rocksdb {
 
 const std::string kCurrentFileName = "CURRENT";
@@ -62,15 +64,14 @@ static size_t GetInfoLogPrefix(const std::string& path, char* dest, int len) {
 }
 
 static std::string MakeFileName(uint64_t number, const char* suffix) {
-  char buf[100];
-  snprintf(buf, sizeof(buf), "%06llu.%s",
-           static_cast<unsigned long long>(number), suffix);
-  return buf;
+  rust::String str = rs::make_file_name(number, suffix);
+  return static_cast<std::string>(str);
 }
 
 static std::string MakeFileName(const std::string& name, uint64_t number,
                                 const char* suffix) {
-  return name + "/" + MakeFileName(number, suffix);
+  rust::String str = rs::make_file_name_full_path(name, number, suffix);
+  return static_cast<std::string>(str);
 }
 
 std::string LogFileName(const std::string& name, uint64_t number) {

--- a/rocksdb-cxx/file/filename.cc
+++ b/rocksdb-cxx/file/filename.cc
@@ -63,14 +63,14 @@ static size_t GetInfoLogPrefix(const std::string& path, char* dest, int len) {
   return write_idx;
 }
 
-std::string LogFileName(const std::string& name, uint64_t number) {
-  assert(number > 0);
-  return static_cast<std::string>(rs::make_file_name_full_path(name, number, "log"));
+rust::String LogFileName(const std::string& name, uint64_t number) {
+  rust::String res = rs::LogFileName(name, number);
+  return res;
 }
 
-std::string LogFileName(uint64_t number) {
-  assert(number > 0);
-  return static_cast<std::string>(rs::make_file_name(number, "log"));
+rust::String LogFileName(uint64_t number) {
+  rust::String res = rs::LogFileName(number);
+  return res;
 }
 
 std::string BlobFileName(uint64_t number) {

--- a/rocksdb-cxx/file/filename.h
+++ b/rocksdb-cxx/file/filename.h
@@ -41,9 +41,9 @@ constexpr char kFilePathSeparator = '/';
 // Return the name of the log file with the specified number
 // in the db named by "dbname".  The result will be prefixed with
 // "dbname".
-extern std::string LogFileName(const std::string& dbname, uint64_t number);
+extern rust::String LogFileName(const std::string& dbname, uint64_t number);
 
-extern std::string LogFileName(uint64_t number);
+extern rust::String LogFileName(uint64_t number);
 
 extern std::string BlobFileName(uint64_t number);
 

--- a/rocksdb-cxx/file/filename.h
+++ b/rocksdb-cxx/file/filename.h
@@ -24,6 +24,7 @@
 #include "rocksdb/transaction_log.h"
 
 #include "rocksdb-rs/src/status.rs.h"
+#include "rocksdb-rs/src/filename.rs.h"
 
 namespace rocksdb {
 
@@ -37,13 +38,6 @@ constexpr char kFilePathSeparator = '\\';
 #else
 constexpr char kFilePathSeparator = '/';
 #endif
-
-// Return the name of the log file with the specified number
-// in the db named by "dbname".  The result will be prefixed with
-// "dbname".
-extern rust::String LogFileName(const std::string& dbname, uint64_t number);
-
-extern rust::String LogFileName(uint64_t number);
 
 extern std::string BlobFileName(uint64_t number);
 

--- a/rocksdb-cxx/include/rocksdb/env.h
+++ b/rocksdb-cxx/include/rocksdb/env.h
@@ -347,6 +347,9 @@ class Env : public Customizable {
 
   // Delete the named file.
   virtual Status DeleteFile(const std::string& fname) = 0;
+  virtual Status DeleteFile(const rust::String& fname) {
+    return DeleteFile(static_cast<std::string>(fname));
+  }
 
   // Truncate the named file to the specified size.
   virtual Status Truncate(const std::string& /*fname*/, size_t /*size*/) {
@@ -367,6 +370,9 @@ class Env : public Customizable {
 
   // Store the size of fname in *file_size.
   virtual Status GetFileSize(const std::string& fname, uint64_t* file_size) = 0;
+  virtual Status GetFileSize(const rust::String& fname, uint64_t* file_size) {
+    return GetFileSize(static_cast<std::string>(fname), file_size);
+  }
 
   // Store the last modification time of fname in *file_mtime.
   virtual Status GetFileModificationTime(const std::string& fname,
@@ -1481,6 +1487,9 @@ class EnvWrapper : public Env {
   Status FileExists(const std::string& f) override {
     return target_.env->FileExists(f);
   }
+  Status FileExists(const rust::string& f) {
+    return target_.env->FileExists(static_cast<std::string>(f));
+  }
   Status GetChildren(const std::string& dir,
                      std::vector<std::string>* r) override {
     return target_.env->GetChildren(dir, r);
@@ -1490,6 +1499,9 @@ class EnvWrapper : public Env {
     return target_.env->GetChildrenFileAttributes(dir, result);
   }
   Status DeleteFile(const std::string& f) override {
+    return target_.env->DeleteFile(f);
+  }
+  Status DeleteFile(const rust::String& f) override {
     return target_.env->DeleteFile(f);
   }
   Status Truncate(const std::string& fname, size_t size) override {

--- a/rocksdb-cxx/table/sst_file_dumper.cc
+++ b/rocksdb-cxx/table/sst_file_dumper.cc
@@ -253,7 +253,7 @@ Status SstFileDumper::CalculateCompressedTableSize(
   *compressed_table_size = table_builder->FileSize();
   assert(num_data_blocks != nullptr);
   *num_data_blocks = table_builder->GetTableProperties().num_data_blocks;
-  return env->DeleteFile(testFileName);
+  return env->DeleteFile(rust::String(testFileName));
 }
 
 Status SstFileDumper::ShowAllCompressionSizes(

--- a/rocksdb-cxx/test_util/testutil.cc
+++ b/rocksdb-cxx/test_util/testutil.cc
@@ -535,6 +535,10 @@ Status TruncateFile(Env* env, const std::string& fname, uint64_t new_length) {
   return s;
 }
 
+Status TruncateFile(Env* env, const rust::String& fname, uint64_t new_length) {
+  return TruncateFile(env, static_cast<std::string>(fname), new_length);
+}
+
 // Try and delete a directory if it exists
 Status TryDeleteDir(Env* env, const std::string& dirname) {
   bool is_dir = false;

--- a/rocksdb-cxx/test_util/testutil.h
+++ b/rocksdb-cxx/test_util/testutil.h
@@ -855,6 +855,7 @@ size_t GetLinesCount(const std::string& fname, const std::string& pattern);
 Status CorruptFile(Env* env, const std::string& fname, int offset,
                    int bytes_to_corrupt, bool verify_checksum = true);
 Status TruncateFile(Env* env, const std::string& fname, uint64_t length);
+Status TruncateFile(Env* env, const rust::String& fname, uint64_t length);
 
 // Try and delete a directory if it exists
 Status TryDeleteDir(Env* env, const std::string& dirname);

--- a/rocksdb-cxx/utilities/transactions/transaction_test.cc
+++ b/rocksdb-cxx/utilities/transactions/transaction_test.cc
@@ -6356,7 +6356,7 @@ TEST_P(TransactionTest, DoubleCrashInRecovery) {
       ASSERT_OK(db->FlushWAL(true));
       DBImpl* db_impl = static_cast_with_check<DBImpl>(db->GetRootDB());
       uint64_t wal_file_id = db_impl->TEST_LogfileNumber();
-      std::string fname = LogFileName(dbname, wal_file_id);
+      std::string fname = std::string(LogFileName(dbname, wal_file_id));
       reinterpret_cast<PessimisticTransactionDB*>(db)->TEST_Crash();
       delete txn;
       delete cf_handle;

--- a/src/filename.rs
+++ b/src/filename.rs
@@ -1,14 +1,16 @@
-#[cxx::bridge(namespace = "rocksdb::rs")]
+#[cxx::bridge(namespace = "rocksdb")]
 mod ffi {
     extern "Rust" {
         // TODO: remove export
+        #[namespace = "rocksdb::rs"]
         fn make_file_name(number: u64, suffix: &str) -> String;
         // TODO: remove export
+        #[namespace = "rocksdb::rs"]
         fn make_file_name_full_path(name: &str, number: u64, suffix: &str) -> String;
         #[cxx_name = "LogFileName"]
         fn log_file_name(number: u64) -> String;
         #[cxx_name = "LogFileName"]
-        fn log_file_name_full_path(name: &str, number: u64) -> String;
+        fn log_file_name_full_path(dbname: &str, number: u64) -> String;
     }
 }
 
@@ -25,9 +27,11 @@ fn log_file_name(number: u64) -> String {
     make_file_name(number, "log")
 }
 
-fn log_file_name_full_path(name: &str, number: u64) -> String {
+/// Return the name of the log file with the specified number in the db named by "dbname". The result will be prefixed
+/// with "dbname".
+fn log_file_name_full_path(dbname: &str, number: u64) -> String {
     assert!(number > 0);
-    make_file_name_full_path(name, number, "log")
+    make_file_name_full_path(dbname, number, "log")
 }
 
 #[cfg(test)]

--- a/src/filename.rs
+++ b/src/filename.rs
@@ -1,8 +1,14 @@
 #[cxx::bridge(namespace = "rocksdb::rs")]
 mod ffi {
     extern "Rust" {
+        // TODO: remove export
         fn make_file_name(number: u64, suffix: &str) -> String;
+        // TODO: remove export
         fn make_file_name_full_path(name: &str, number: u64, suffix: &str) -> String;
+        #[cxx_name = "LogFileName"]
+        fn log_file_name(number: u64) -> String;
+        #[cxx_name = "LogFileName"]
+        fn log_file_name_full_path(name: &str, number: u64) -> String;
     }
 }
 
@@ -12,6 +18,16 @@ fn make_file_name(number: u64, suffix: &str) -> String {
 
 fn make_file_name_full_path(name: &str, number: u64, suffix: &str) -> String {
     format!("{}/{}", name, make_file_name(number, suffix))
+}
+
+fn log_file_name(number: u64) -> String {
+    assert!(number > 0);
+    make_file_name(number, "log")
+}
+
+fn log_file_name_full_path(name: &str, number: u64) -> String {
+    assert!(number > 0);
+    make_file_name_full_path(name, number, "log")
 }
 
 #[cfg(test)]

--- a/src/filename.rs
+++ b/src/filename.rs
@@ -1,0 +1,33 @@
+#[cxx::bridge(namespace = "rocksdb::rs")]
+mod ffi {
+    extern "Rust" {
+        fn make_file_name(number: u64, suffix: &str) -> String;
+        fn make_file_name_full_path(name: &str, number: u64, suffix: &str) -> String;
+    }
+}
+
+fn make_file_name(number: u64, suffix: &str) -> String {
+    format!("{:06}.{}", number, suffix)
+}
+
+fn make_file_name_full_path(name: &str, number: u64, suffix: &str) -> String {
+    format!("{}/{}", name, make_file_name(number, suffix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_file_name_simple() {
+        assert_eq!(make_file_name(1, "simple"), "000001.simple");
+    }
+
+    #[test]
+    fn make_file_name_full_path_simple() {
+        assert_eq!(
+            make_file_name_full_path("test", 1, "simple"),
+            "test/000001.simple"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cache;
 mod coding_lean;
 pub mod compression_type;
 pub mod env;
+mod filename;
 mod hash;
 pub mod port_defs;
 pub mod slice;


### PR DESCRIPTION
This ports the following methods from filename.cc to rust:
- MakeFileName
- LogFileName

This also increases the number of parallel jobs in linux tests since GitHub increased the core counts on the provided runners.