### PR TITLE
introduce build-cpp feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - name: Build
-      run: cargo build
+      run: cargo build --features build-cpp
     - name: Run tests
-      run: cargo test
+      run: cargo test --features build-cpp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ xxhash-rust = { version = "0.8.10", features = ["xxh3"] }
 
 [build-dependencies]
 cxx-build = { version = "1.0.122", features = ["parallel"] }
+
+[features]
+build-cpp = []

--- a/build.rs
+++ b/build.rs
@@ -330,9 +330,6 @@ const SOURCES: &[&str] = &[
 ];
 
 fn main() {
-    // This will be set when building rocksdb-rs from cmake.
-    let skip_cpp_build = std::env::var("SKIP_CPP_BUILD").map_or(false, |x| x == "1");
-
     let bridges = vec![
         "src/cache.rs",
         "src/coding.rs",
@@ -371,7 +368,7 @@ fn main() {
     config.std("c++17");
     config.warnings(false);
 
-    if !skip_cpp_build {
+    if cfg!(feature = "build-cpp") {
         config.flag("-pthread");
         config.flag("-Wsign-compare");
         config.flag("-Wshadow");
@@ -397,7 +394,6 @@ fn main() {
 
     config.compile("rocksdb-cxx");
 
-    println!("cargo:rerun-if-env-changed=SKIP_CPP_BUILD");
     println!("cargo:rerun-if-changed=rocksdb-cxx");
     println!("cargo:rerun-if-changed=build_version.cc");
 

--- a/rocksdb-cxx/CMakeLists.txt
+++ b/rocksdb-cxx/CMakeLists.txt
@@ -1111,7 +1111,6 @@ set(ROCKSDBRS_TRIPLE_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/cargo/build/${Rust_CARG
 set(ROCKSDBRS_CXXBRDIGE ${ROCKSDBRS_TRIPLE_OUT_DIR}/cxxbridge)
 
 corrosion_import_crate(MANIFEST_PATH ../Cargo.toml)
-corrosion_set_env_vars(rocksdb_rs SKIP_CPP_BUILD=1)
 
 add_library(${ROCKSDB_STATIC_LIB} STATIC ${SOURCES} ${BUILD_VERSION_CC})
 target_include_directories(${ROCKSDB_STATIC_LIB} PUBLIC ${ROCKSDBRS_CXXBRDIGE})


### PR DESCRIPTION
Only build C++ files in build.rs if the build-cpp feature is enabled. Cxx bindings will still get generated, but we won't build any c++ code.

This makes it possible to run `cargo check` without having to wait for c++ compilation.

Fixes #39.